### PR TITLE
Align WatsonxAiChatOptions model_id

### DIFF
--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatOptions.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatOptions.java
@@ -95,7 +95,7 @@ public class WatsonxAiChatOptions implements ToolCallingChatOptions {
   private Integer seed;
 
   /** Model is the identifier of the LLM Model to be used */
-  @JsonProperty("model")
+  @JsonProperty("model_id")
   private String model;
 
   /**

--- a/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatModelTest.java
+++ b/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatModelTest.java
@@ -182,7 +182,7 @@ public class WatsonxAiChatModelTest {
 
     var optionsMap = options.toMap();
     assertNotNull(optionsMap);
-    assertEquals("test-model", optionsMap.get("model"));
+    assertEquals("test-model", optionsMap.get("model_id"));
     assertEquals(0.5, optionsMap.get("temperature"));
     assertEquals(0.9, optionsMap.get("top_p"));
     assertEquals(1000, optionsMap.get("max_tokens"));


### PR DESCRIPTION
In the WatsonxAiChatOptions and WatsonxAiChatRequest model property were misaligned causing model to be null in WatsonxAiChatModel:

`
    WatsonxAiChatOptions requestOptions = (WatsonxAiChatOptions) requestPrompt.getOptions();
    request = ModelOptionsUtils.merge(requestOptions, request, WatsonxAiChatRequest.class);
`