### PR TITLE
fix(watsonx): update API version and refactor embedding parameters structure

### DIFF
--- a/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/io/github/springaicommunity/watsonx/autoconfigure/embedding/WatsonxAiEmbeddingProperties.java
+++ b/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/io/github/springaicommunity/watsonx/autoconfigure/embedding/WatsonxAiEmbeddingProperties.java
@@ -17,6 +17,7 @@
 package io.github.springaicommunity.watsonx.autoconfigure.embedding;
 
 import io.github.springaicommunity.watsonx.embedding.WatsonxAiEmbeddingOptions;
+import io.github.springaicommunity.watsonx.embedding.WatsonxAiEmbeddingRequest;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -30,11 +31,14 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 public class WatsonxAiEmbeddingProperties {
 
   public static final String CONFIG_PREFIX = "spring.ai.watsonx.ai.embedding";
-  public static final String DEFAULT_EMBEDDING_ENDPOINT = "/ml/v1/text/embeddings";
-  public static final String DEFAULT_VERSION = "2024-08-15";
 
-  private String embeddingEndpoint = DEFAULT_EMBEDDING_ENDPOINT;
-  private String version = DEFAULT_VERSION;
+  private String embeddingEndpoint = "/ml/v1/text/embeddings";
+
+  /**
+   * API version date to use, in YYYY-MM-DD format. Example: 2024-10-17. See the <a
+   * href="https://cloud.ibm.com/apidocs/watsonx-ai#api-versioning">watsonx.ai API versioning</a>
+   */
+  private String version = "2024-10-17";
 
   /**
    * The default options to use when calling the watsonx.ai Embedding API. These can be overridden
@@ -44,7 +48,7 @@ public class WatsonxAiEmbeddingProperties {
   private WatsonxAiEmbeddingOptions options =
       WatsonxAiEmbeddingOptions.builder()
           .model("ibm/slate-125m-english-rtrvr")
-          .truncateInputTokens(512)
+          .parameters(new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null))
           .build();
 
   public String getEmbeddingEndpoint() {

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/aot/WatsonxAiRuntimeHints.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/aot/WatsonxAiRuntimeHints.java
@@ -27,8 +27,6 @@ import org.springframework.lang.Nullable;
  * {@code WatsonxAiRuntimeHints} is responsible for registering runtime hints for watsonx API
  * classes.
  *
- * <p>TODO: add more explanation
- *
  * @author Tristan Mahinay
  * @since 1.1.0-SNAPSHOT
  */

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatModel.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatModel.java
@@ -592,7 +592,7 @@ public class WatsonxAiChatModel implements ChatModel {
     return ChatResponseMetadata.builder()
         .id(result.id() != null ? result.id() : "")
         .usage(usage)
-        .model(result.modelId() != null ? result.modelId() : "")
+        .model(result.model() != null ? result.model() : "")
         .keyValue("created", result.created() != null ? result.created() : 0)
         .keyValue("model_version", result.modelVersion() != null ? result.modelVersion() : "")
         .build();

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatRequest.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatRequest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public final class WatsonxAiChatRequest {
 
   @JsonProperty("model_id")
-  private String modelId;
+  private String model;
 
   @JsonProperty("project_id")
   private String projectId;
@@ -93,7 +93,7 @@ public final class WatsonxAiChatRequest {
   public WatsonxAiChatRequest() {}
 
   private WatsonxAiChatRequest(Builder builder) {
-    this.modelId = builder.modelId;
+    this.model = builder.model;
     this.projectId = builder.projectId;
     this.toolChoiceOption = builder.toolChoiceOption;
     this.messages = builder.messages;
@@ -115,8 +115,8 @@ public final class WatsonxAiChatRequest {
   }
 
   // Getters
-  public String modelId() {
-    return modelId;
+  public String model() {
+    return model;
   }
 
   public String projectId() {
@@ -197,7 +197,7 @@ public final class WatsonxAiChatRequest {
 
   public Builder toBuilder() {
     return new Builder()
-        .modelId(this.modelId)
+        .model(this.model)
         .projectId(this.projectId)
         .toolChoiceOption(this.toolChoiceOption)
         .messages(this.messages)
@@ -219,7 +219,7 @@ public final class WatsonxAiChatRequest {
   }
 
   public static class Builder {
-    private String modelId;
+    private String model;
     private String projectId;
     private String toolChoiceOption;
     private List<TextChatMessage> messages;
@@ -241,8 +241,8 @@ public final class WatsonxAiChatRequest {
 
     private Builder() {}
 
-    public Builder modelId(String modelId) {
-      this.modelId = modelId;
+    public Builder model(String model) {
+      this.model = model;
       return this;
     }
 

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatResponse.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatResponse.java
@@ -34,7 +34,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record WatsonxAiChatResponse(
     @JsonProperty("id") String id,
-    @JsonProperty("model_id") String modelId,
+    @JsonProperty("model_id") String model,
     @JsonProperty("created") Integer created,
     @JsonProperty("choices") List<TextChatResultChoice> choices,
     @JsonProperty("model_version") String modelVersion,

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModel.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModel.java
@@ -69,7 +69,7 @@ public class WatsonxAiEmbeddingModel implements EmbeddingModel {
           WatsonxAiEmbeddingRequest watsonxRequest =
               WatsonxAiEmbeddingRequest.builder()
                   .inputs(request.getInstructions())
-                  .modelId(options.getModel())
+                  .model(options.getModel())
                   .parameters(createEmbeddingParameters(options))
                   .build();
 
@@ -116,9 +116,6 @@ public class WatsonxAiEmbeddingModel implements EmbeddingModel {
         if (watsonxOptions.getParameters() != null) {
           mergedOptions.setParameters(watsonxOptions.getParameters());
         }
-        if (watsonxOptions.getTruncateInputTokens() != null) {
-          mergedOptions.setTruncateInputTokens(watsonxOptions.getTruncateInputTokens());
-        }
       }
     }
 
@@ -127,19 +124,19 @@ public class WatsonxAiEmbeddingModel implements EmbeddingModel {
 
   private WatsonxAiEmbeddingRequest.EmbeddingParameters createEmbeddingParameters(
       WatsonxAiEmbeddingOptions options) {
-    if (options.getTruncateInputTokens() == null && options.getParameters() == null) {
+    if (options.getParameters() == null) {
       return null;
     }
 
     WatsonxAiEmbeddingRequest.EmbeddingReturnOptions returnOptions = null;
-    if (options.getParameters() != null && options.getParameters().get("input_text") != null) {
+    if (options.getParameters() != null && options.getParameters().returnOptions() != null) {
       returnOptions =
           new WatsonxAiEmbeddingRequest.EmbeddingReturnOptions(
-              (Boolean) options.getParameters().get("input_text"));
+              (Boolean) options.getParameters().returnOptions().inputText());
     }
 
     return new WatsonxAiEmbeddingRequest.EmbeddingParameters(
-        options.getTruncateInputTokens(), returnOptions);
+        options.getParameters().truncateInputTokens(), returnOptions);
   }
 
   private EmbeddingResponse toEmbeddingResponse(WatsonxAiEmbeddingResponse watsonxResponse) {
@@ -166,7 +163,7 @@ public class WatsonxAiEmbeddingModel implements EmbeddingModel {
 
     EmbeddingResponseMetadata metadata =
         new EmbeddingResponseMetadata(
-            watsonxResponse.modelId() != null ? watsonxResponse.modelId() : "unknown", null);
+            watsonxResponse.model() != null ? watsonxResponse.model() : "unknown", null);
 
     return new EmbeddingResponse(embeddings, metadata);
   }

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptions.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptions.java
@@ -17,7 +17,8 @@
 package io.github.springaicommunity.watsonx.embedding;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.springaicommunity.watsonx.embedding.WatsonxAiEmbeddingRequest.EmbeddingParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.embedding.EmbeddingOptions;
@@ -34,16 +35,17 @@ public class WatsonxAiEmbeddingOptions implements EmbeddingOptions {
 
   private static final Logger logger = LoggerFactory.getLogger(WatsonxAiEmbeddingOptions.class);
 
+  @JsonProperty("model_id")
   private String model;
-  private Map<String, Object> parameters;
-  private Integer truncateInputTokens;
+
+  @JsonProperty("parameters")
+  private EmbeddingParameters parameters;
 
   public WatsonxAiEmbeddingOptions() {}
 
   private WatsonxAiEmbeddingOptions(Builder builder) {
     this.model = builder.model;
     this.parameters = builder.parameters;
-    this.truncateInputTokens = builder.truncateInputTokens;
   }
 
   @Override
@@ -65,20 +67,12 @@ public class WatsonxAiEmbeddingOptions implements EmbeddingOptions {
     logger.warn("Watson AI API doesn't support dimensions parameter");
   }
 
-  public Map<String, Object> getParameters() {
+  public EmbeddingParameters getParameters() {
     return parameters;
   }
 
-  public void setParameters(Map<String, Object> parameters) {
+  public void setParameters(EmbeddingParameters parameters) {
     this.parameters = parameters;
-  }
-
-  public Integer getTruncateInputTokens() {
-    return truncateInputTokens;
-  }
-
-  public void setTruncateInputTokens(Integer truncateInputTokens) {
-    this.truncateInputTokens = truncateInputTokens;
   }
 
   public String getEncodingFormat() {
@@ -95,16 +89,12 @@ public class WatsonxAiEmbeddingOptions implements EmbeddingOptions {
   }
 
   public Builder toBuilder() {
-    return new Builder()
-        .model(this.model)
-        .parameters(this.parameters)
-        .truncateInputTokens(this.truncateInputTokens);
+    return new Builder().model(this.model).parameters(this.parameters);
   }
 
   public static class Builder {
     private String model;
-    private Map<String, Object> parameters;
-    private Integer truncateInputTokens;
+    private EmbeddingParameters parameters;
 
     private Builder() {}
 
@@ -113,13 +103,8 @@ public class WatsonxAiEmbeddingOptions implements EmbeddingOptions {
       return this;
     }
 
-    public Builder parameters(Map<String, Object> parameters) {
+    public Builder parameters(EmbeddingParameters parameters) {
       this.parameters = parameters;
-      return this;
-    }
-
-    public Builder truncateInputTokens(Integer truncateInputTokens) {
-      this.truncateInputTokens = truncateInputTokens;
       return this;
     }
 

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingRequest.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingRequest.java
@@ -34,7 +34,7 @@ public final class WatsonxAiEmbeddingRequest {
   private List<String> inputs;
 
   @JsonProperty("model_id")
-  private String modelId;
+  private String model;
 
   @JsonProperty("project_id")
   private String projectId;
@@ -46,7 +46,7 @@ public final class WatsonxAiEmbeddingRequest {
 
   private WatsonxAiEmbeddingRequest(Builder builder) {
     this.inputs = builder.inputs;
-    this.modelId = builder.modelId;
+    this.model = builder.model;
     this.projectId = builder.projectId;
     this.parameters = builder.parameters;
   }
@@ -55,8 +55,8 @@ public final class WatsonxAiEmbeddingRequest {
     return inputs;
   }
 
-  public String modelId() {
-    return modelId;
+  public String model() {
+    return model;
   }
 
   public String projectId() {
@@ -74,14 +74,14 @@ public final class WatsonxAiEmbeddingRequest {
   public Builder toBuilder() {
     return new Builder()
         .inputs(this.inputs)
-        .modelId(this.modelId)
+        .model(this.model)
         .projectId(this.projectId)
         .parameters(this.parameters);
   }
 
   public static class Builder {
     private List<String> inputs;
-    private String modelId;
+    private String model;
     private String projectId;
     private EmbeddingParameters parameters;
 
@@ -92,8 +92,8 @@ public final class WatsonxAiEmbeddingRequest {
       return this;
     }
 
-    public Builder modelId(String modelId) {
-      this.modelId = modelId;
+    public Builder model(String model) {
+      this.model = model;
       return this;
     }
 

--- a/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingResponse.java
+++ b/watsonx-ai-core/src/main/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingResponse.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Response from the Watson AI Embedding API. Full documentation can be found at <a
@@ -30,7 +31,7 @@ import java.util.List;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record WatsonxAiEmbeddingResponse(
-    @JsonProperty("model_id") String modelId,
+    @JsonProperty("model_id") String model,
     @JsonProperty("created_at") LocalDateTime createdAt,
     @JsonProperty("results") List<Embedding> results,
     @JsonProperty("input_token_count") Integer inputTokenCount) {
@@ -43,4 +44,19 @@ public record WatsonxAiEmbeddingResponse(
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public record EmbeddingInputResult(@JsonProperty("text") String text) {}
+
+  /**
+   * Optional details coming from the service and related to the API call or the associated
+   * resource.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record SystemDetails(@JsonProperty("warnings") List<Warning> warnings) {}
+
+  /** Any warnings coming from the system. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record Warning(
+      @JsonProperty("message") String message,
+      @JsonProperty("id") String id,
+      @JsonProperty("more_info") String moreInfo,
+      @JsonProperty("additional_properties") Map<String, Object> additionalProperties) {}
 }

--- a/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptionsTest.java
+++ b/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptionsTest.java
@@ -18,8 +18,6 @@ package io.github.springaicommunity.watsonx.embedding;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -37,17 +35,20 @@ class WatsonxAiEmbeddingOptionsTest {
 
     @Test
     void createBasicEmbeddingOptionsWithDefaultValues() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
       WatsonxAiEmbeddingOptions options =
           WatsonxAiEmbeddingOptions.builder()
               .model("ibm/slate-125m-english-rtrvr")
-              .truncateInputTokens(512)
+              .parameters(parameters)
               .build();
 
       assertAll(
           "Basic options validation",
           () -> assertEquals("ibm/slate-125m-english-rtrvr", options.getModel()),
-          () -> assertEquals(512, options.getTruncateInputTokens()),
-          () -> assertNull(options.getParameters()),
+          () -> assertNotNull(options.getParameters()),
+          () -> assertEquals(512, options.getParameters().truncateInputTokens()),
           () -> assertNull(options.getDimensions()));
     }
 
@@ -59,7 +60,6 @@ class WatsonxAiEmbeddingOptionsTest {
       assertAll(
           "Minimal options validation",
           () -> assertEquals("ibm/slate-30m-english-rtrvr", options.getModel()),
-          () -> assertNull(options.getTruncateInputTokens()),
           () -> assertNull(options.getParameters()),
           () -> assertNull(options.getDimensions()));
     }
@@ -71,7 +71,6 @@ class WatsonxAiEmbeddingOptionsTest {
       assertAll(
           "Empty options validation",
           () -> assertNull(options.getModel()),
-          () -> assertNull(options.getTruncateInputTokens()),
           () -> assertNull(options.getParameters()),
           () -> assertNull(options.getDimensions()));
     }
@@ -82,36 +81,35 @@ class WatsonxAiEmbeddingOptionsTest {
 
     @Test
     void createAdvancedOptionsWithAllParameters() {
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("input_text", true);
-      parameters.put("custom_param", "value");
+      WatsonxAiEmbeddingRequest.EmbeddingReturnOptions returnOptions =
+          new WatsonxAiEmbeddingRequest.EmbeddingReturnOptions(true);
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(1024, returnOptions);
 
       WatsonxAiEmbeddingOptions options =
           WatsonxAiEmbeddingOptions.builder()
               .model("ibm/slate-125m-english-rtrvr")
-              .truncateInputTokens(1024)
               .parameters(parameters)
               .build();
 
       assertAll(
           "Advanced options validation",
           () -> assertEquals("ibm/slate-125m-english-rtrvr", options.getModel()),
-          () -> assertEquals(1024, options.getTruncateInputTokens()),
           () -> assertNotNull(options.getParameters()),
-          () -> assertEquals(true, options.getParameters().get("input_text")),
-          () -> assertEquals("value", options.getParameters().get("custom_param")));
+          () -> assertEquals(1024, options.getParameters().truncateInputTokens()),
+          () -> assertNotNull(options.getParameters().returnOptions()),
+          () -> assertEquals(true, options.getParameters().returnOptions().inputText()));
     }
 
     @Test
-    void handleEmptyParameters() {
+    void handleNullParameters() {
       WatsonxAiEmbeddingOptions options =
           WatsonxAiEmbeddingOptions.builder()
               .model("ibm/slate-30m-english-rtrvr")
-              .parameters(new HashMap<>())
+              .parameters(null)
               .build();
 
-      assertNotNull(options.getParameters());
-      assertTrue(options.getParameters().isEmpty());
+      assertNull(options.getParameters());
     }
   }
 
@@ -127,8 +125,11 @@ class WatsonxAiEmbeddingOptionsTest {
       };
 
       for (String model : supportedModels) {
+        WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+            new WatsonxAiEmbeddingRequest.EmbeddingParameters(256, null);
+
         WatsonxAiEmbeddingOptions options =
-            WatsonxAiEmbeddingOptions.builder().model(model).truncateInputTokens(256).build();
+            WatsonxAiEmbeddingOptions.builder().model(model).parameters(parameters).build();
 
         assertEquals(model, options.getModel(), "Model should be set correctly for: " + model);
       }
@@ -143,26 +144,34 @@ class WatsonxAiEmbeddingOptionsTest {
       assertAll(
           "TruncateInputTokens range validation",
           () -> {
+            WatsonxAiEmbeddingRequest.EmbeddingParameters lowParams =
+                new WatsonxAiEmbeddingRequest.EmbeddingParameters(1, null);
             WatsonxAiEmbeddingOptions lowTokens =
-                WatsonxAiEmbeddingOptions.builder().truncateInputTokens(1).build();
-            assertEquals(1, lowTokens.getTruncateInputTokens());
+                WatsonxAiEmbeddingOptions.builder().parameters(lowParams).build();
+            assertEquals(1, lowTokens.getParameters().truncateInputTokens());
           },
           () -> {
+            WatsonxAiEmbeddingRequest.EmbeddingParameters midParams =
+                new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
             WatsonxAiEmbeddingOptions midTokens =
-                WatsonxAiEmbeddingOptions.builder().truncateInputTokens(512).build();
-            assertEquals(512, midTokens.getTruncateInputTokens());
+                WatsonxAiEmbeddingOptions.builder().parameters(midParams).build();
+            assertEquals(512, midTokens.getParameters().truncateInputTokens());
           },
           () -> {
+            WatsonxAiEmbeddingRequest.EmbeddingParameters highParams =
+                new WatsonxAiEmbeddingRequest.EmbeddingParameters(2048, null);
             WatsonxAiEmbeddingOptions highTokens =
-                WatsonxAiEmbeddingOptions.builder().truncateInputTokens(2048).build();
-            assertEquals(2048, highTokens.getTruncateInputTokens());
+                WatsonxAiEmbeddingOptions.builder().parameters(highParams).build();
+            assertEquals(2048, highTokens.getParameters().truncateInputTokens());
           });
     }
 
     @Test
     void handleParametersWithInputTextFlag() {
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("input_text", true);
+      WatsonxAiEmbeddingRequest.EmbeddingReturnOptions returnOptions =
+          new WatsonxAiEmbeddingRequest.EmbeddingReturnOptions(true);
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, returnOptions);
 
       WatsonxAiEmbeddingOptions options =
           WatsonxAiEmbeddingOptions.builder()
@@ -170,13 +179,15 @@ class WatsonxAiEmbeddingOptionsTest {
               .parameters(parameters)
               .build();
 
-      assertTrue((Boolean) options.getParameters().get("input_text"));
+      assertTrue(options.getParameters().returnOptions().inputText());
     }
 
     @Test
     void handleParametersWithInputTextFlagFalse() {
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("input_text", false);
+      WatsonxAiEmbeddingRequest.EmbeddingReturnOptions returnOptions =
+          new WatsonxAiEmbeddingRequest.EmbeddingReturnOptions(false);
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, returnOptions);
 
       WatsonxAiEmbeddingOptions options =
           WatsonxAiEmbeddingOptions.builder()
@@ -184,7 +195,7 @@ class WatsonxAiEmbeddingOptionsTest {
               .parameters(parameters)
               .build();
 
-      assertFalse((Boolean) options.getParameters().get("input_text"));
+      assertFalse(options.getParameters().returnOptions().inputText());
     }
   }
 
@@ -193,13 +204,14 @@ class WatsonxAiEmbeddingOptionsTest {
 
     @Test
     void supportMethodChaining() {
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("input_text", true);
+      WatsonxAiEmbeddingRequest.EmbeddingReturnOptions returnOptions =
+          new WatsonxAiEmbeddingRequest.EmbeddingReturnOptions(true);
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, returnOptions);
 
       WatsonxAiEmbeddingOptions options =
           WatsonxAiEmbeddingOptions.builder()
               .model("ibm/slate-125m-english-rtrvr")
-              .truncateInputTokens(512)
               .parameters(parameters)
               .build();
 
@@ -209,16 +221,21 @@ class WatsonxAiEmbeddingOptionsTest {
 
     @Test
     void createMultipleInstancesIndependently() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters params1 =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(256, null);
+      WatsonxAiEmbeddingRequest.EmbeddingParameters params2 =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
       WatsonxAiEmbeddingOptions options1 =
           WatsonxAiEmbeddingOptions.builder()
               .model("ibm/slate-125m-english-rtrvr")
-              .truncateInputTokens(256)
+              .parameters(params1)
               .build();
 
       WatsonxAiEmbeddingOptions options2 =
           WatsonxAiEmbeddingOptions.builder()
               .model("ibm/slate-30m-english-rtrvr")
-              .truncateInputTokens(512)
+              .parameters(params2)
               .build();
 
       assertAll(
@@ -226,27 +243,33 @@ class WatsonxAiEmbeddingOptionsTest {
           () -> assertNotSame(options1, options2),
           () -> assertEquals("ibm/slate-125m-english-rtrvr", options1.getModel()),
           () -> assertEquals("ibm/slate-30m-english-rtrvr", options2.getModel()),
-          () -> assertEquals(256, options1.getTruncateInputTokens()),
-          () -> assertEquals(512, options2.getTruncateInputTokens()));
+          () -> assertEquals(256, options1.getParameters().truncateInputTokens()),
+          () -> assertEquals(512, options2.getParameters().truncateInputTokens()));
     }
 
     @Test
     void supportToBuilderPattern() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters originalParams =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(256, null);
+
       WatsonxAiEmbeddingOptions original =
           WatsonxAiEmbeddingOptions.builder()
               .model("original-model")
-              .truncateInputTokens(256)
+              .parameters(originalParams)
               .build();
 
+      WatsonxAiEmbeddingRequest.EmbeddingParameters modifiedParams =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
       WatsonxAiEmbeddingOptions modified =
-          original.toBuilder().model("modified-model").truncateInputTokens(512).build();
+          original.toBuilder().model("modified-model").parameters(modifiedParams).build();
 
       assertAll(
           "ToBuilder pattern validation",
           () -> assertEquals("original-model", original.getModel()),
-          () -> assertEquals(256, original.getTruncateInputTokens()),
+          () -> assertEquals(256, original.getParameters().truncateInputTokens()),
           () -> assertEquals("modified-model", modified.getModel()),
-          () -> assertEquals(512, modified.getTruncateInputTokens()));
+          () -> assertEquals(512, modified.getParameters().truncateInputTokens()));
     }
   }
 
@@ -262,22 +285,14 @@ class WatsonxAiEmbeddingOptionsTest {
     }
 
     @Test
-    void setTruncateInputTokensDirectly() {
-      WatsonxAiEmbeddingOptions options = new WatsonxAiEmbeddingOptions();
-      options.setTruncateInputTokens(1024);
-
-      assertEquals(1024, options.getTruncateInputTokens());
-    }
-
-    @Test
     void setParametersDirectly() {
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("test", "value");
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(1024, null);
 
       WatsonxAiEmbeddingOptions options = new WatsonxAiEmbeddingOptions();
       options.setParameters(parameters);
 
-      assertEquals("value", options.getParameters().get("test"));
+      assertEquals(1024, options.getParameters().truncateInputTokens());
     }
 
     @Test
@@ -302,23 +317,21 @@ class WatsonxAiEmbeddingOptionsTest {
 
     @Test
     void validateOptionsState() {
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("input_text", true);
+      WatsonxAiEmbeddingRequest.EmbeddingReturnOptions returnOptions =
+          new WatsonxAiEmbeddingRequest.EmbeddingReturnOptions(true);
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, returnOptions);
 
       WatsonxAiEmbeddingOptions options =
-          WatsonxAiEmbeddingOptions.builder()
-              .model("test-model")
-              .truncateInputTokens(512)
-              .parameters(parameters)
-              .build();
+          WatsonxAiEmbeddingOptions.builder().model("test-model").parameters(parameters).build();
 
       assertAll(
           "Options validation",
           () -> assertNotNull(options),
           () -> assertEquals("test-model", options.getModel()),
-          () -> assertTrue(options.getTruncateInputTokens() > 0),
           () -> assertNotNull(options.getParameters()),
-          () -> assertTrue((Boolean) options.getParameters().get("input_text")));
+          () -> assertTrue(options.getParameters().truncateInputTokens() > 0),
+          () -> assertTrue(options.getParameters().returnOptions().inputText()));
     }
 
     @Test


### PR DESCRIPTION

- Update default API version from 2024-08-15 to 2024-10-17
- Replace truncateInputTokens with structured EmbeddingParameters object
- Change modelId field to model in chat requests for API consistency
- Remove obsolete constants and TODO comments
- Add comprehensive API versioning documentation links