### PR TITLE
fix(pom.xml): watsonx-ai-core should not be an optional dependency

### DIFF
--- a/spring-ai-autoconfigure-model-watsonx-ai/pom.xml
+++ b/spring-ai-autoconfigure-model-watsonx-ai/pom.xml
@@ -22,7 +22,6 @@
 		<dependency>
 			<groupId>io.github.springaicommunity</groupId>
 			<artifactId>watsonx-ai-core</artifactId>
-			<optional>true</optional>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The readme as is, is not enough, either update the installation section with `watsonx-ai-core` dependency, or remove the optional from the starter, this way importing the starter will be enough