### PR TITLE
Fix IT tests execution

### DIFF
--- a/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatClientIT.java
+++ b/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatClientIT.java
@@ -31,8 +31,6 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.retry.RetryUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -48,10 +46,9 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Federico Mariani
  * @since 1.1.0-SNAPSHOT
  */
-@RestClientTest
-public class WatsonxAiChatClientTest {
+public class WatsonxAiChatClientIT {
 
-  @Autowired private RestClient.Builder restClientBuilder;
+  private RestClient.Builder restClientBuilder;
 
   private MockRestServiceServer mockServer;
 
@@ -70,6 +67,7 @@ public class WatsonxAiChatClientTest {
 
   @BeforeEach
   void setUp() {
+    restClientBuilder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
 
     // Create a simple ResponseErrorHandler for testing

--- a/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatClientMultimodalityIT.java
+++ b/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatClientMultimodalityIT.java
@@ -37,8 +37,6 @@ import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.retry.RetryUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -60,10 +58,9 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Federico Mariani
  * @since 1.1.0-SNAPSHOT
  */
-@RestClientTest
 public class WatsonxAiChatClientMultimodalityIT {
 
-  @Autowired private RestClient.Builder restClientBuilder;
+  private RestClient.Builder restClientBuilder;
 
   private MockRestServiceServer mockServer;
 
@@ -85,6 +82,7 @@ public class WatsonxAiChatClientMultimodalityIT {
 
   @BeforeEach
   void setUp() {
+    restClientBuilder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
 
     // Create a simple ResponseErrorHandler for testing

--- a/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatClientToolsIT.java
+++ b/watsonx-ai-core/src/test/java/io/github/springaicommunity/watsonx/chat/WatsonxAiChatClientToolsIT.java
@@ -36,8 +36,6 @@ import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.function.FunctionToolCallback;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -54,10 +52,9 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Federico Mariani
  * @since 1.1.0-SNAPSHOT
  */
-@RestClientTest
 public class WatsonxAiChatClientToolsIT {
 
-  @Autowired private RestClient.Builder restClientBuilder;
+  private RestClient.Builder restClientBuilder;
 
   private MockRestServiceServer mockServer;
 
@@ -122,6 +119,7 @@ public class WatsonxAiChatClientToolsIT {
 
   @BeforeEach
   void setUp() {
+    restClientBuilder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
 
     // Create a simple ResponseErrorHandler for testing


### PR DESCRIPTION
After the removal of the main class https://github.com/spring-ai-community/spring-ai-watsonx-ai/commit/e864d204b0848949c41167a3831848c91a5e7282#diff-1df677512d21c78f55d1d68f3e7ff4d4ea27f74a7247eeadf18330fcd5cf3e30 which is totally fine, the tests using `RestClientTest` started failing (a full Spring context and a main class is needed). It is not a big deal since we were already mocking most of the stuff, the `RestClientTest` is not really needed