### PR TITLE
build: add maven-deploy-plugin version management and fix indentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -222,8 +223,14 @@
         
         <plugin>
             <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>${flatten-maven-plugin.version}</version>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>${flatten-maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>${maven-deploy-plugin.version}</version>
         </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Add maven-deploy-plugin version 3.1.4 to plugin management
- Fix indentation for flatten-maven-plugin configuration
- Ensures consistent plugin versioning across the project