### PR TITLE
ci(maven-central): update publish workflow and configure flatten-maven-plugin

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -15,24 +15,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set up Java      
+      - name: Set up Java
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'corretto'
+          distribution: 'temurin'
           cache: 'maven'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE   
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
           
       - name: Build and Test
-        run: mvn clean verify          
-        
+        run: mvn clean verify
+
       - name: Publish to Sonatype
-        run: mvn -ntp clean deploy -Prelease,javadoc
+        run: |
+          mvn --batch-mode \
+            -Prelease \
+            -Pjavadoc \
+            deploy
         env:
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ out/
 ### VS Code ###
 .vscode/
 
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -221,10 +221,38 @@
             </executions>
         </plugin>
         
-        <plugin>
+       <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>flatten-maven-plugin</artifactId>
             <version>${flatten-maven-plugin.version}</version>
+            <executions>
+                <execution>
+                    <id>flatten</id>
+                    <phase>process-resources</phase>
+                    <goals>
+                        <goal>flatten</goal>
+                    </goals>
+                    <configuration>
+                        <updatePomFile>true</updatePomFile>
+                        <flattenMode>ossrh</flattenMode>
+                        <pomElements>
+                            <distributionManagement>remove</distributionManagement>
+                            <dependencyManagement>remove</dependencyManagement>
+                            <repositories>remove</repositories>
+                            <scm>keep</scm>
+                            <url>keep</url>
+                            <organization>resolve</organization>
+                        </pomElements>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>clean</id>
+                    <phase>clean</phase>
+                    <goals>
+                        <goal>clean</goal>
+                    </goals>
+                </execution>
+            </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION


- Switch Java distribution from corretto to temurin in setup-java action
- Add Node.js v20 setup step to workflow
- Consolidate build and deploy into single Maven command with batch mode
- Reorder environment variables in deploy step for consistency
- Configure flatten-maven-plugin with ossrh mode to generate deployment-ready POM
- Add flatten execution on process-resources phase with updatePomFile flag
- Add flatten clean execution to remove generated .flattened-pom.xml artifacts
- Update .gitignore to exclude .flattened-pom.xml files

These changes improve the CI/CD pipeline and ensure proper POM flattening for Maven Central publication requirements.