### PR TITLE
fix(watsonx-tool-calling): define function parameter as map according to API and convert tool response

### DIFF
--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatModel.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatModel.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springaicommunity.watsonx.chat.WatsonxAiChatRequest.TextChatParameterFunction;
+import org.springaicommunity.watsonx.chat.WatsonxAiChatRequest.TextChatParameterTool;
 import org.springaicommunity.watsonx.chat.message.TextChatMessage;
 import org.springaicommunity.watsonx.chat.message.TextChatMessage.TextChatFunctionCall;
 import org.springaicommunity.watsonx.chat.message.user.TextChatUserContent;
@@ -450,8 +452,8 @@ public class WatsonxAiChatModel implements ChatModel {
                         .map(
                             toolResponse ->
                                 new TextChatMessage(
-                                    toolResponse.name(),
                                     toolResponse.responseData(),
+                                    toolResponse.name(),
                                     toolResponse.id()))
                         .toList();
                   } else if (MessageType.USER.equals(message.getMessageType())) {
@@ -605,13 +607,13 @@ public class WatsonxAiChatModel implements ChatModel {
       List<ToolDefinition> toolDefinitions) {
     return toolDefinitions.stream()
         .map(
-            toolDefinition ->
-                new WatsonxAiChatRequest.TextChatParameterTool(
-                    ToolType.FUNCTION,
-                    new WatsonxAiChatRequest.TextChatParameterFunction(
-                        toolDefinition.name(),
-                        toolDefinition.description(),
-                        toolDefinition.inputSchema())))
+            toolDefinition -> {
+              var parameters = ModelOptionsUtils.jsonToMap(toolDefinition.inputSchema());
+              return new TextChatParameterTool(
+                  ToolType.FUNCTION,
+                  new TextChatParameterFunction(
+                      toolDefinition.name(), toolDefinition.description(), parameters));
+            })
         .toList();
   }
 

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatRequest.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatRequest.java
@@ -372,9 +372,10 @@ public final class WatsonxAiChatRequest {
     private final String description;
 
     @JsonProperty("parameters")
-    private final String parameters;
+    private final Map<String, Object> parameters;
 
-    public TextChatParameterFunction(String name, String description, String parameters) {
+    public TextChatParameterFunction(
+        String name, String description, Map<String, Object> parameters) {
       this.name = name;
       this.description = description;
       this.parameters = parameters;
@@ -388,7 +389,7 @@ public final class WatsonxAiChatRequest {
       return description;
     }
 
-    public String parameters() {
+    public Map<String, Object> parameters() {
       return parameters;
     }
   }


### PR DESCRIPTION
Fixes [GH-48](https://github.com/spring-ai-community/spring-ai-watsonx-ai/issues/48)

Using the watsonx.ai Spring AI starter exposes a tool calling issue where function parameters are sent as plain strings, but watsonx expects typed JSON objects, resulting in error responses.

This PR maps the schema using ObjectMapper and fixes tool request/response handling so tool calls work correctly with the watsonx starter.