### PR TITLE
docs: standardize product naming to watsonx.ai in embedding API

### DIFF
--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptions.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
- * Options for watsonx Embedding API. Configuration options that can be passed to control the
+ * Options for watsonx.ai Embedding API. Configuration options that can be passed to control the
  * behavior of the embedding model.
  *
  * @author Tristan Mahinay

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingRequest.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
- * Request for the Watson AI Embedding API. Full documentation can be found at <a
- * href="https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings">Watson AI Text Embeddings</a>.
+ * Request for the watsonx.ai Embedding API. Full documentation can be found at <a
+ * href="https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings">watsonx.ai Text Embeddings</a>.
  *
  * @author Tristan Mahinay
  * @since 1.0.0

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingResponse.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Response from the Watson AI Embedding API. Full documentation can be found at <a
- * href="https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings">Watson AI Text Embeddings</a>.
+ * Response from the watsonx.ai Embedding API. Full documentation can be found at <a
+ * href="https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings">watsonx.ai Text Embeddings</a>.
  *
  * @author Tristan Mahinay
  * @since 1.0.0


### PR DESCRIPTION
Update Javadoc comments across embedding API classes (WatsonxAiEmbeddingOptions, WatsonxAiEmbeddingRequest, WatsonxAiEmbeddingResponse) to consistently use watsonx.ai branding instead of Watson AI or watsonx. Also updates copyright year to 2025-2026. This ensures uniform product naming throughout the embedding API documentation.