### PR TITLE
feat(watsonx): implement equals, hashCode, and toString for options classes

### DIFF
--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatOptions.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.lang.Nullable;
@@ -488,6 +490,71 @@ public class WatsonxAiChatOptions implements ToolCallingChatOptions {
   @Override
   public WatsonxAiChatOptions copy() {
     return fromOptions(this);
+  }
+
+  @Override
+  public String toString() {
+    return "WatsonxAiChatOptions: " + ModelOptionsUtils.toJsonString(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WatsonxAiChatOptions other = (WatsonxAiChatOptions) o;
+    return Objects.equals(this.temperature, other.temperature)
+        && Objects.equals(this.topP, other.topP)
+        && Objects.equals(this.stopSequences, other.stopSequences)
+        && Objects.equals(this.presencePenalty, other.presencePenalty)
+        && Objects.equals(this.frequencyPenalty, other.frequencyPenalty)
+        && Objects.equals(this.seed, other.seed)
+        && Objects.equals(this.model, other.model)
+        && Objects.equals(this.tools, other.tools)
+        && Objects.equals(this.toolChoiceOption, other.toolChoiceOption)
+        && Objects.equals(this.toolChoice, other.toolChoice)
+        && Objects.equals(this.toolCallbacks, other.toolCallbacks)
+        && Objects.equals(this.toolNames, other.toolNames)
+        && Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
+        && Objects.equals(this.toolContext, other.toolContext)
+        && Objects.equals(this.logitBias, other.logitBias)
+        && Objects.equals(this.logprobs, other.logprobs)
+        && Objects.equals(this.topLogprobs, other.topLogprobs)
+        && Objects.equals(this.maxTokens, other.maxTokens)
+        && Objects.equals(this.maxCompletionTokens, other.maxCompletionTokens)
+        && Objects.equals(this.n, other.n)
+        && Objects.equals(this.timeLimit, other.timeLimit)
+        && Objects.equals(this.additional, other.additional);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        this.temperature,
+        this.topP,
+        this.stopSequences,
+        this.presencePenalty,
+        this.frequencyPenalty,
+        this.seed,
+        this.model,
+        this.tools,
+        this.toolChoiceOption,
+        this.toolChoice,
+        this.toolCallbacks,
+        this.toolNames,
+        this.internalToolExecutionEnabled,
+        this.toolContext,
+        this.logitBias,
+        this.logprobs,
+        this.topLogprobs,
+        this.maxTokens,
+        this.maxCompletionTokens,
+        this.n,
+        this.timeLimit,
+        this.additional);
   }
 
   public static class Builder {

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptions.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptions.java
@@ -18,10 +18,12 @@ package org.springaicommunity.watsonx.embedding;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.watsonx.embedding.WatsonxAiEmbeddingRequest.EmbeddingParameters;
 import org.springframework.ai.embedding.EmbeddingOptions;
+import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -92,6 +94,33 @@ public class WatsonxAiEmbeddingOptions implements EmbeddingOptions {
 
   public Builder toBuilder() {
     return new Builder().model(this.model).parameters(this.parameters);
+  }
+
+  public WatsonxAiEmbeddingOptions copy() {
+    return toBuilder().build();
+  }
+
+  @Override
+  public String toString() {
+    return "WatsonxAiEmbeddingOptions: " + ModelOptionsUtils.toJsonString(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WatsonxAiEmbeddingOptions other = (WatsonxAiEmbeddingOptions) o;
+    return Objects.equals(this.model, other.model)
+        && Objects.equals(this.parameters, other.parameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.model, this.parameters);
   }
 
   public static class Builder {

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationOptions.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springaicommunity.watsonx.moderation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.moderation.ModerationOptions;
 
 /**
@@ -99,6 +101,40 @@ public class WatsonxAiModerationOptions implements ModerationOptions {
         .pii(this.pii)
         .graniteGuardian(this.graniteGuardian)
         .build();
+  }
+
+  public WatsonxAiModerationOptions copy() {
+    return builder()
+        .model(this.model)
+        .hap(this.hap)
+        .pii(this.pii)
+        .graniteGuardian(this.graniteGuardian)
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return "WatsonxAiModerationOptions: " + ModelOptionsUtils.toJsonString(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WatsonxAiModerationOptions other = (WatsonxAiModerationOptions) o;
+    return Objects.equals(this.model, other.model)
+        && Objects.equals(this.hap, other.hap)
+        && Objects.equals(this.pii, other.pii)
+        && Objects.equals(this.graniteGuardian, other.graniteGuardian);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.model, this.hap, this.pii, this.graniteGuardian);
   }
 
   public static final class Builder {

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/chat/WatsonxAiChatOptionsTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/chat/WatsonxAiChatOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -279,6 +279,215 @@ class WatsonxAiChatOptionsTest {
           () -> assertTrue(options.getTemperature() >= 0.0 && options.getTemperature() <= 1.0),
           () -> assertTrue(options.getTopP() >= 0.0 && options.getTopP() <= 1.0),
           () -> assertTrue(options.getMaxTokens() > 0));
+    }
+  }
+
+  @Nested
+  class CopyMethodTests {
+
+    @Test
+    void copyCreatesSeparateInstance() {
+      WatsonxAiChatOptions original =
+          WatsonxAiChatOptions.builder()
+              .model("ibm/granite-3-3-8b-instruct")
+              .temperature(0.7)
+              .topP(0.9)
+              .maxTokens(1024)
+              .presencePenalty(0.1)
+              .seed(42)
+              .build();
+
+      WatsonxAiChatOptions copy = original.copy();
+
+      assertAll(
+          "Copy creates separate instance",
+          () -> assertNotSame(original, copy),
+          () -> assertEquals(original.getModel(), copy.getModel()),
+          () -> assertEquals(original.getTemperature(), copy.getTemperature()),
+          () -> assertEquals(original.getTopP(), copy.getTopP()),
+          () -> assertEquals(original.getMaxTokens(), copy.getMaxTokens()),
+          () -> assertEquals(original.getPresencePenalty(), copy.getPresencePenalty()),
+          () -> assertEquals(original.getSeed(), copy.getSeed()));
+    }
+
+    @Test
+    void copyWithNullFieldsHandledCorrectly() {
+      WatsonxAiChatOptions original = WatsonxAiChatOptions.builder().model("test-model").build();
+
+      WatsonxAiChatOptions copy = original.copy();
+
+      assertAll(
+          "Copy with null fields",
+          () -> assertNotSame(original, copy),
+          () -> assertEquals(original.getModel(), copy.getModel()),
+          () -> assertNull(copy.getTemperature()),
+          () -> assertNull(copy.getTopP()),
+          () -> assertNull(copy.getMaxTokens()));
+    }
+  }
+
+  @Nested
+  class ToStringMethodTests {
+
+    @Test
+    void toStringReturnsJsonRepresentation() {
+      WatsonxAiChatOptions options =
+          WatsonxAiChatOptions.builder()
+              .model("ibm/granite-3-3-8b-instruct")
+              .temperature(0.7)
+              .topP(0.9)
+              .maxTokens(1024)
+              .build();
+
+      String result = options.toString();
+
+      assertAll(
+          "ToString validation",
+          () -> assertNotNull(result),
+          () -> assertTrue(result.startsWith("WatsonxAiChatOptions: ")),
+          () -> assertTrue(result.contains("ibm/granite-3-3-8b-instruct")));
+    }
+
+    @Test
+    void toStringWithMinimalOptions() {
+      WatsonxAiChatOptions options = WatsonxAiChatOptions.builder().model("test-model").build();
+
+      String result = options.toString();
+
+      assertNotNull(result);
+      assertTrue(result.startsWith("WatsonxAiChatOptions: "));
+    }
+  }
+
+  @Nested
+  class EqualsMethodTests {
+
+    @Test
+    void equalsReturnsTrueForSameInstance() {
+      WatsonxAiChatOptions options =
+          WatsonxAiChatOptions.builder().model("test-model").temperature(0.7).build();
+
+      assertEquals(options, options);
+    }
+
+    @Test
+    void equalsReturnsTrueForEqualOptions() {
+      WatsonxAiChatOptions options1 =
+          WatsonxAiChatOptions.builder()
+              .model("ibm/granite-3-3-8b-instruct")
+              .temperature(0.7)
+              .topP(0.9)
+              .maxTokens(1024)
+              .build();
+
+      WatsonxAiChatOptions options2 =
+          WatsonxAiChatOptions.builder()
+              .model("ibm/granite-3-3-8b-instruct")
+              .temperature(0.7)
+              .topP(0.9)
+              .maxTokens(1024)
+              .build();
+
+      assertEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentModel() {
+      WatsonxAiChatOptions options1 =
+          WatsonxAiChatOptions.builder().model("model1").temperature(0.7).build();
+
+      WatsonxAiChatOptions options2 =
+          WatsonxAiChatOptions.builder().model("model2").temperature(0.7).build();
+
+      assertNotEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentTemperature() {
+      WatsonxAiChatOptions options1 =
+          WatsonxAiChatOptions.builder().model("test-model").temperature(0.7).build();
+
+      WatsonxAiChatOptions options2 =
+          WatsonxAiChatOptions.builder().model("test-model").temperature(0.5).build();
+
+      assertNotEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForNull() {
+      WatsonxAiChatOptions options = WatsonxAiChatOptions.builder().model("test-model").build();
+
+      assertNotEquals(options, null);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentClass() {
+      WatsonxAiChatOptions options = WatsonxAiChatOptions.builder().model("test-model").build();
+
+      assertNotEquals(options, "string");
+    }
+
+    @Test
+    void equalsHandlesNullFields() {
+      WatsonxAiChatOptions options1 = WatsonxAiChatOptions.builder().model("test-model").build();
+
+      WatsonxAiChatOptions options2 = WatsonxAiChatOptions.builder().model("test-model").build();
+
+      assertEquals(options1, options2);
+    }
+  }
+
+  @Nested
+  class HashCodeMethodTests {
+
+    @Test
+    void hashCodeConsistentForSameInstance() {
+      WatsonxAiChatOptions options =
+          WatsonxAiChatOptions.builder().model("test-model").temperature(0.7).topP(0.9).build();
+
+      int hashCode1 = options.hashCode();
+      int hashCode2 = options.hashCode();
+
+      assertEquals(hashCode1, hashCode2);
+    }
+
+    @Test
+    void hashCodeSameForEqualOptions() {
+      WatsonxAiChatOptions options1 =
+          WatsonxAiChatOptions.builder()
+              .model("ibm/granite-3-3-8b-instruct")
+              .temperature(0.7)
+              .topP(0.9)
+              .maxTokens(1024)
+              .build();
+
+      WatsonxAiChatOptions options2 =
+          WatsonxAiChatOptions.builder()
+              .model("ibm/granite-3-3-8b-instruct")
+              .temperature(0.7)
+              .topP(0.9)
+              .maxTokens(1024)
+              .build();
+
+      assertEquals(options1.hashCode(), options2.hashCode());
+    }
+
+    @Test
+    void hashCodeDifferentForDifferentOptions() {
+      WatsonxAiChatOptions options1 =
+          WatsonxAiChatOptions.builder().model("model1").temperature(0.7).build();
+
+      WatsonxAiChatOptions options2 =
+          WatsonxAiChatOptions.builder().model("model2").temperature(0.7).build();
+
+      assertNotEquals(options1.hashCode(), options2.hashCode());
+    }
+
+    @Test
+    void hashCodeHandlesNullFields() {
+      WatsonxAiChatOptions options = WatsonxAiChatOptions.builder().model("test-model").build();
+
+      assertDoesNotThrow(() -> options.hashCode());
     }
   }
 }

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptionsTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,6 +364,222 @@ class WatsonxAiEmbeddingOptionsTest {
           WatsonxAiEmbeddingOptions.builder().model("test-model").build();
 
       assertNull(options.getEncodingFormat());
+    }
+  }
+
+  @Nested
+  class CopyMethodTests {
+
+    @Test
+    void copyCreatesSeparateInstance() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
+      WatsonxAiEmbeddingOptions original =
+          WatsonxAiEmbeddingOptions.builder()
+              .model("ibm/slate-125m-english-rtrvr")
+              .parameters(parameters)
+              .build();
+
+      WatsonxAiEmbeddingOptions copy = original.copy();
+
+      assertAll(
+          "Copy creates separate instance",
+          () -> assertNotSame(original, copy),
+          () -> assertEquals(original.getModel(), copy.getModel()),
+          () -> assertEquals(original.getParameters(), copy.getParameters()));
+    }
+
+    @Test
+    void copyWithNullFieldsHandledCorrectly() {
+      WatsonxAiEmbeddingOptions original =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      WatsonxAiEmbeddingOptions copy = original.copy();
+
+      assertAll(
+          "Copy with null fields",
+          () -> assertNotSame(original, copy),
+          () -> assertEquals(original.getModel(), copy.getModel()),
+          () -> assertNull(copy.getParameters()));
+    }
+  }
+
+  @Nested
+  class ToStringMethodTests {
+
+    @Test
+    void toStringReturnsJsonRepresentation() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
+      WatsonxAiEmbeddingOptions options =
+          WatsonxAiEmbeddingOptions.builder()
+              .model("ibm/slate-125m-english-rtrvr")
+              .parameters(parameters)
+              .build();
+
+      String result = options.toString();
+
+      assertAll(
+          "ToString validation",
+          () -> assertNotNull(result),
+          () -> assertTrue(result.startsWith("WatsonxAiEmbeddingOptions: ")),
+          () -> assertTrue(result.contains("ibm/slate-125m-english-rtrvr")));
+    }
+
+    @Test
+    void toStringWithMinimalOptions() {
+      WatsonxAiEmbeddingOptions options =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      String result = options.toString();
+
+      assertNotNull(result);
+      assertTrue(result.startsWith("WatsonxAiEmbeddingOptions: "));
+    }
+  }
+
+  @Nested
+  class EqualsMethodTests {
+
+    @Test
+    void equalsReturnsTrueForSameInstance() {
+      WatsonxAiEmbeddingOptions options =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      assertEquals(options, options);
+    }
+
+    @Test
+    void equalsReturnsTrueForEqualOptions() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
+      WatsonxAiEmbeddingOptions options1 =
+          WatsonxAiEmbeddingOptions.builder()
+              .model("ibm/slate-125m-english-rtrvr")
+              .parameters(parameters)
+              .build();
+
+      WatsonxAiEmbeddingOptions options2 =
+          WatsonxAiEmbeddingOptions.builder()
+              .model("ibm/slate-125m-english-rtrvr")
+              .parameters(parameters)
+              .build();
+
+      assertEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentModel() {
+      WatsonxAiEmbeddingOptions options1 =
+          WatsonxAiEmbeddingOptions.builder().model("model1").build();
+
+      WatsonxAiEmbeddingOptions options2 =
+          WatsonxAiEmbeddingOptions.builder().model("model2").build();
+
+      assertNotEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentParameters() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters params1 =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(256, null);
+      WatsonxAiEmbeddingRequest.EmbeddingParameters params2 =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
+      WatsonxAiEmbeddingOptions options1 =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").parameters(params1).build();
+
+      WatsonxAiEmbeddingOptions options2 =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").parameters(params2).build();
+
+      assertNotEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForNull() {
+      WatsonxAiEmbeddingOptions options =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      assertNotEquals(options, null);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentClass() {
+      WatsonxAiEmbeddingOptions options =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      assertNotEquals(options, "string");
+    }
+
+    @Test
+    void equalsHandlesNullFields() {
+      WatsonxAiEmbeddingOptions options1 =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      WatsonxAiEmbeddingOptions options2 =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      assertEquals(options1, options2);
+    }
+  }
+
+  @Nested
+  class HashCodeMethodTests {
+
+    @Test
+    void hashCodeConsistentForSameInstance() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
+      WatsonxAiEmbeddingOptions options =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").parameters(parameters).build();
+
+      int hashCode1 = options.hashCode();
+      int hashCode2 = options.hashCode();
+
+      assertEquals(hashCode1, hashCode2);
+    }
+
+    @Test
+    void hashCodeSameForEqualOptions() {
+      WatsonxAiEmbeddingRequest.EmbeddingParameters parameters =
+          new WatsonxAiEmbeddingRequest.EmbeddingParameters(512, null);
+
+      WatsonxAiEmbeddingOptions options1 =
+          WatsonxAiEmbeddingOptions.builder()
+              .model("ibm/slate-125m-english-rtrvr")
+              .parameters(parameters)
+              .build();
+
+      WatsonxAiEmbeddingOptions options2 =
+          WatsonxAiEmbeddingOptions.builder()
+              .model("ibm/slate-125m-english-rtrvr")
+              .parameters(parameters)
+              .build();
+
+      assertEquals(options1.hashCode(), options2.hashCode());
+    }
+
+    @Test
+    void hashCodeDifferentForDifferentOptions() {
+      WatsonxAiEmbeddingOptions options1 =
+          WatsonxAiEmbeddingOptions.builder().model("model1").build();
+
+      WatsonxAiEmbeddingOptions options2 =
+          WatsonxAiEmbeddingOptions.builder().model("model2").build();
+
+      assertNotEquals(options1.hashCode(), options2.hashCode());
+    }
+
+    @Test
+    void hashCodeHandlesNullFields() {
+      WatsonxAiEmbeddingOptions options =
+          WatsonxAiEmbeddingOptions.builder().model("test-model").build();
+
+      assertDoesNotThrow(() -> options.hashCode());
     }
   }
 }

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationModelIT.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationModelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,9 @@ import org.springframework.retry.RetryCallback;
 import org.springframework.retry.support.RetryTemplate;
 
 /**
- * JUnit 5 test class for WatsonxAiModerationModel functionality. Tests moderation model operations
- * using mocking for external dependencies.
+ * Integration test class for WatsonxAiModerationModel using Spring AI ModerationModel APIs. This
+ * test demonstrates integration with Spring AI's high-level ModerationRequest and
+ * ModerationResponse APIs.
  *
  * @author Federico Mariani
  * @since 1.0.0

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationOptionsTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationOptionsTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.moderation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JUnit 5 test class for WatsonxAiModerationOptions functionality and configuration. Tests the
+ * moderation options builder pattern and configuration validation.
+ *
+ * @author Tristan Mahinay
+ * @since 1.0.2
+ */
+class WatsonxAiModerationOptionsTest {
+
+  @Nested
+  class BuilderTests {
+
+    @Test
+    void optionsBuilderWithThreshold() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().hap(0.8f).pii(0.9f).graniteGuardian(0.6f).build();
+
+      assertNotNull(options);
+      assertNotNull(options.getHap());
+      assertEquals(0.8f, options.getHap().threshold());
+      assertNotNull(options.getPii());
+      assertEquals(0.9f, options.getPii().threshold());
+      assertNotNull(options.getGraniteGuardian());
+      assertEquals(0.6f, options.getGraniteGuardian().threshold());
+    }
+
+    @Test
+    void detectorConfigEnabled() {
+      WatsonxAiModerationRequest.DetectorConfig config =
+          WatsonxAiModerationRequest.DetectorConfig.enabled();
+
+      assertNotNull(config);
+      assertNull(config.threshold());
+    }
+
+    @Test
+    void detectorConfigWithThreshold() {
+      WatsonxAiModerationRequest.DetectorConfig config =
+          WatsonxAiModerationRequest.DetectorConfig.of(0.85f);
+
+      assertNotNull(config);
+      assertEquals(0.85f, config.threshold());
+    }
+
+    @Test
+    void toDetectorsConversion() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().hap(0.75f).pii(0.85f).graniteGuardian(0.6f).build();
+
+      WatsonxAiModerationRequest.Detectors detectors = options.toDetectors();
+
+      assertNotNull(detectors);
+      assertNotNull(detectors.hap());
+      assertNotNull(detectors.pii());
+      assertNotNull(detectors.graniteGuardian());
+    }
+  }
+
+  @Nested
+  class CopyMethodTests {
+
+    @Test
+    void copyCreatesSeparateInstance() {
+      WatsonxAiModerationOptions original =
+          WatsonxAiModerationOptions.builder()
+              .model("granite_guardian")
+              .hap(0.75f)
+              .pii(0.85f)
+              .graniteGuardian(0.6f)
+              .build();
+
+      WatsonxAiModerationOptions copy = original.copy();
+
+      assertNotNull(copy);
+      assertEquals(original.getModel(), copy.getModel());
+      assertEquals(original.getHap(), copy.getHap());
+      assertEquals(original.getPii(), copy.getPii());
+      assertEquals(original.getGraniteGuardian(), copy.getGraniteGuardian());
+      assertNotEquals(System.identityHashCode(original), System.identityHashCode(copy));
+    }
+
+    @Test
+    void copyWithNullFieldsHandledCorrectly() {
+      WatsonxAiModerationOptions original =
+          WatsonxAiModerationOptions.builder().model("test-model").build();
+
+      WatsonxAiModerationOptions copy = original.copy();
+
+      assertNotNull(copy);
+      assertEquals(original.getModel(), copy.getModel());
+      assertNull(copy.getHap());
+      assertNull(copy.getPii());
+      assertNull(copy.getGraniteGuardian());
+    }
+  }
+
+  @Nested
+  class ToStringMethodTests {
+
+    @Test
+    void toStringReturnsJsonRepresentation() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder()
+              .model("granite_guardian")
+              .hap(0.75f)
+              .pii(0.85f)
+              .build();
+
+      String result = options.toString();
+
+      assertNotNull(result);
+      assertEquals(true, result.startsWith("WatsonxAiModerationOptions: "));
+    }
+
+    @Test
+    void toStringWithMinimalOptions() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().model("test-model").build();
+
+      String result = options.toString();
+
+      assertNotNull(result);
+      assertEquals(true, result.startsWith("WatsonxAiModerationOptions: "));
+    }
+  }
+
+  @Nested
+  class EqualsMethodTests {
+
+    @Test
+    void equalsReturnsTrueForSameInstance() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().model("test-model").hap(0.75f).build();
+
+      assertEquals(options, options);
+    }
+
+    @Test
+    void equalsReturnsTrueForEqualOptions() {
+      WatsonxAiModerationOptions options1 =
+          WatsonxAiModerationOptions.builder()
+              .model("granite_guardian")
+              .hap(0.75f)
+              .pii(0.85f)
+              .build();
+
+      WatsonxAiModerationOptions options2 =
+          WatsonxAiModerationOptions.builder()
+              .model("granite_guardian")
+              .hap(0.75f)
+              .pii(0.85f)
+              .build();
+
+      assertEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentModel() {
+      WatsonxAiModerationOptions options1 =
+          WatsonxAiModerationOptions.builder().model("model1").hap(0.75f).build();
+
+      WatsonxAiModerationOptions options2 =
+          WatsonxAiModerationOptions.builder().model("model2").hap(0.75f).build();
+
+      assertNotEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentHap() {
+      WatsonxAiModerationOptions options1 =
+          WatsonxAiModerationOptions.builder().model("test-model").hap(0.75f).build();
+
+      WatsonxAiModerationOptions options2 =
+          WatsonxAiModerationOptions.builder().model("test-model").hap(0.85f).build();
+
+      assertNotEquals(options1, options2);
+    }
+
+    @Test
+    void equalsReturnsFalseForNull() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().model("test-model").build();
+
+      assertNotEquals(options, null);
+    }
+
+    @Test
+    void equalsReturnsFalseForDifferentClass() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().model("test-model").build();
+
+      assertNotEquals(options, "string");
+    }
+
+    @Test
+    void equalsHandlesNullFields() {
+      WatsonxAiModerationOptions options1 =
+          WatsonxAiModerationOptions.builder().model("test-model").build();
+
+      WatsonxAiModerationOptions options2 =
+          WatsonxAiModerationOptions.builder().model("test-model").build();
+
+      assertEquals(options1, options2);
+    }
+  }
+
+  @Nested
+  class HashCodeMethodTests {
+
+    @Test
+    void hashCodeConsistentForSameInstance() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().model("test-model").hap(0.75f).pii(0.85f).build();
+
+      int hashCode1 = options.hashCode();
+      int hashCode2 = options.hashCode();
+
+      assertEquals(hashCode1, hashCode2);
+    }
+
+    @Test
+    void hashCodeSameForEqualOptions() {
+      WatsonxAiModerationOptions options1 =
+          WatsonxAiModerationOptions.builder()
+              .model("granite_guardian")
+              .hap(0.75f)
+              .pii(0.85f)
+              .build();
+
+      WatsonxAiModerationOptions options2 =
+          WatsonxAiModerationOptions.builder()
+              .model("granite_guardian")
+              .hap(0.75f)
+              .pii(0.85f)
+              .build();
+
+      assertEquals(options1.hashCode(), options2.hashCode());
+    }
+
+    @Test
+    void hashCodeDifferentForDifferentOptions() {
+      WatsonxAiModerationOptions options1 =
+          WatsonxAiModerationOptions.builder().model("model1").hap(0.75f).build();
+
+      WatsonxAiModerationOptions options2 =
+          WatsonxAiModerationOptions.builder().model("model2").hap(0.75f).build();
+
+      assertNotEquals(options1.hashCode(), options2.hashCode());
+    }
+
+    @Test
+    void hashCodeHandlesNullFields() {
+      WatsonxAiModerationOptions options =
+          WatsonxAiModerationOptions.builder().model("test-model").build();
+
+      assertNotNull(options.hashCode());
+    }
+  }
+}

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/moderation/WatsonxAiModerationTest.java
@@ -1,13 +1,35 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springaicommunity.watsonx.moderation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestClient;
 
+/**
+ * JUnit 5 test class for WatsonxAiModerationModel functionality. Tests moderation model operations
+ * using mocking for external dependencies.
+ *
+ * @author Federico Mariani
+ * @since 1.0.0
+ */
 public class WatsonxAiModerationTest {
 
   @Test
@@ -56,59 +78,5 @@ public class WatsonxAiModerationTest {
 
     assertNotNull(moderationModel.getDefaultOptions());
     assertEquals(defaultOptions, moderationModel.getDefaultOptions());
-  }
-
-  @Test
-  void optionsBuilderWithThreshold() {
-    // When
-    WatsonxAiModerationOptions options =
-        WatsonxAiModerationOptions.builder().hap(0.8f).pii(0.9f).graniteGuardian(0.6f).build();
-
-    // Then
-    assertNotNull(options);
-    assertNotNull(options.getHap());
-    assertEquals(0.8f, options.getHap().threshold());
-    assertNotNull(options.getPii());
-    assertEquals(0.9f, options.getPii().threshold());
-    assertNotNull(options.getGraniteGuardian());
-    assertEquals(0.6f, options.getGraniteGuardian().threshold());
-  }
-
-  @Test
-  void detectorConfigEnabled() {
-    // When
-    WatsonxAiModerationRequest.DetectorConfig config =
-        WatsonxAiModerationRequest.DetectorConfig.enabled();
-
-    // Then
-    assertNotNull(config);
-    assertNull(config.threshold());
-  }
-
-  @Test
-  void detectorConfigWithThreshold() {
-    // When
-    WatsonxAiModerationRequest.DetectorConfig config =
-        WatsonxAiModerationRequest.DetectorConfig.of(0.85f);
-
-    // Then
-    assertNotNull(config);
-    assertEquals(0.85f, config.threshold());
-  }
-
-  @Test
-  void toDetectorsConversion() {
-    // Given
-    WatsonxAiModerationOptions options =
-        WatsonxAiModerationOptions.builder().hap(0.75f).pii(0.85f).graniteGuardian(0.6f).build();
-
-    // When
-    WatsonxAiModerationRequest.Detectors detectors = options.toDetectors();
-
-    // Then
-    assertNotNull(detectors);
-    assertNotNull(detectors.hap());
-    assertNotNull(detectors.pii());
-    assertNotNull(detectors.graniteGuardian());
   }
 }


### PR DESCRIPTION
Fixes GH-55

Add proper equals(), hashCode(), and toString() implementations to WatsonxAiChatOptions and WatsonxAiEmbeddingOptions classes following Java best practices. The toString() method utilizes ModelOptionsUtils for JSON serialization. Includes comprehensive unit tests to verify equality, hash code consistency, and string representation functionality.

Updated copyright year to 2025-2026.