### PR TITLE
feat(watsonx): add observability support to WatsonxAiEmbeddingModel

### DIFF
--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModelIT.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
+import io.micrometer.observation.ObservationRegistry;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,7 +91,10 @@ public class WatsonxAiEmbeddingModelIT {
 
     embeddingModel =
         new WatsonxAiEmbeddingModel(
-            watsonxAiEmbeddingApi, defaultOptions, RetryUtils.DEFAULT_RETRY_TEMPLATE);
+            watsonxAiEmbeddingApi,
+            defaultOptions,
+            ObservationRegistry.NOOP,
+            RetryUtils.DEFAULT_RETRY_TEMPLATE);
   }
 
   @Test

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModelObservationIT.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModelObservationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,10 @@ public class WatsonxAiEmbeddingModelObservationIT {
 
     embeddingModel =
         new WatsonxAiEmbeddingModel(
-            watsonxAiEmbeddingApi, defaultOptions, RetryUtils.DEFAULT_RETRY_TEMPLATE);
+            watsonxAiEmbeddingApi,
+            defaultOptions,
+            observationRegistry,
+            RetryUtils.DEFAULT_RETRY_TEMPLATE);
   }
 
   @Test
@@ -161,6 +164,7 @@ public class WatsonxAiEmbeddingModelObservationIT {
         new WatsonxAiEmbeddingModel(
             watsonxAiEmbeddingApi,
             embeddingModel.getDefaultOptions(),
+            observationRegistry,
             RetryUtils.DEFAULT_RETRY_TEMPLATE);
 
     EmbeddingRequest request = new EmbeddingRequest(List.of("Observation test"), null);

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModelTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/embedding/WatsonxAiEmbeddingModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.micrometer.observation.ObservationRegistry;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +66,8 @@ class WatsonxAiEmbeddingModelTest {
 
     // Initialize the embedding model
     embeddingModel =
-        new WatsonxAiEmbeddingModel(watsonxAiEmbeddingApi, defaultOptions, retryTemplate);
+        new WatsonxAiEmbeddingModel(
+            watsonxAiEmbeddingApi, defaultOptions, ObservationRegistry.NOOP, retryTemplate);
 
     // Mock retry template to execute directly without retry logic
     doAnswer(
@@ -93,7 +95,9 @@ class WatsonxAiEmbeddingModelTest {
     void constructorWithNullApiThrowsException() {
       assertThrows(
           IllegalArgumentException.class,
-          () -> new WatsonxAiEmbeddingModel(null, defaultOptions, retryTemplate),
+          () ->
+              new WatsonxAiEmbeddingModel(
+                  null, defaultOptions, ObservationRegistry.NOOP, retryTemplate),
           "WatsonxAiEmbeddingApi must not be null");
     }
 
@@ -101,15 +105,29 @@ class WatsonxAiEmbeddingModelTest {
     void constructorWithNullOptionsThrowsException() {
       assertThrows(
           IllegalArgumentException.class,
-          () -> new WatsonxAiEmbeddingModel(watsonxAiEmbeddingApi, null, retryTemplate),
+          () ->
+              new WatsonxAiEmbeddingModel(
+                  watsonxAiEmbeddingApi, null, ObservationRegistry.NOOP, retryTemplate),
           "WatsonxAiEmbeddingOptions must not be null");
+    }
+
+    @Test
+    void constructorWithNullObservationRegistryThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              new WatsonxAiEmbeddingModel(
+                  watsonxAiEmbeddingApi, defaultOptions, null, retryTemplate),
+          "ObservationRegistry must not be null");
     }
 
     @Test
     void constructorWithNullRetryTemplateThrowsException() {
       assertThrows(
           IllegalArgumentException.class,
-          () -> new WatsonxAiEmbeddingModel(watsonxAiEmbeddingApi, defaultOptions, null),
+          () ->
+              new WatsonxAiEmbeddingModel(
+                  watsonxAiEmbeddingApi, defaultOptions, ObservationRegistry.NOOP, null),
           "RetryTemplate must not be null");
     }
   }


### PR DESCRIPTION
Fixes GH-57

Add Micrometer observation support to the WatsonxAi embedding model to enable tracing and monitoring capabilities. This includes:

- Inject ObservationRegistry and EmbeddingModelObservationConvention into the embedding model autoconfiguration
- Integrate observation context for tracking embedding operations
- Support custom observation conventions with fallback to default implementation
- Update copyright year to 2025-2026

This change enables better observability and monitoring of embedding operations in production environments, following Spring AI's standard observation patterns.