### PR TITLE
ci: add auto-assign workflow for pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for spring-ai-watsonx-ai
+# These owners will be automatically requested for review when someone opens a pull request.
+# More info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @spring-ai-community/watsonx-team

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -24,22 +24,3 @@ jobs:
               assignees: [pr.user.login]
             });
             console.log(`Assigned PR #${pr.number} to ${pr.user.login}`);
-
-      - name: Request review from watsonx-team
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pr = context.payload.pull_request;
-            try {
-              await github.rest.pulls.requestReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-                team_reviewers: ['watsonx-team']
-              });
-              console.log(`Requested review from watsonx-team for PR #${pr.number}`);
-            } catch (error) {
-              console.error(`Failed to request review: ${error.message}`);
-              // Don't fail the workflow if team review request fails
-            }


### PR DESCRIPTION
- Auto-assign PRs to their authors
- Request reviews from watsonx-team automatically
- Triggers on PR open/reopen events