### PR TITLE
docs: expand function calling documentation with Tools and ToolCallback

### DIFF
--- a/docs/src/main/antora/modules/ROOT/pages/chat/index.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/chat/index.adoc
@@ -249,11 +249,20 @@ The https://github.com/spring-ai-community/spring-ai-watsonx-ai/blob/main/watson
 
 You can register custom Java functions with the `WatsonxAiChatModel` and have the Watsonx.ai model intelligently choose to output a JSON object containing arguments to call one or many of the registered functions. This allows you to connect the LLM capabilities with external tools and APIs.
 
-The Watsonx.ai models will intelligently choose when to call functions based on the input provided. Here's a complete example:
+Function calling works by:
+
+1. **Defining tools** - You register functions that the model can call
+2. **Model decision** - The model analyzes the user's request and decides which tool(s) to invoke
+3. **Tool execution** - Spring AI executes the selected tools with the model-provided arguments
+4. **Response generation** - The model uses the tool results to generate a final response
+
+=== Registering Functions as Spring Beans
+
+The simplest approach is to register your functions as Spring beans with the `@Description` annotation:
 
 [source,java]
 ----
-@Component  
+@Component
 public class MockWeatherService implements Function<MockWeatherService.Request, MockWeatherService.Response> {
 
     public enum Unit { C, F }
@@ -265,6 +274,21 @@ public class MockWeatherService implements Function<MockWeatherService.Request, 
     }
 }
 ----
+
+[source,java]
+----
+@Configuration
+public class FunctionConfiguration {
+
+    @Bean
+    @Description("Get the weather in location") // function description
+    public Function<MockWeatherService.Request, MockWeatherService.Response> currentWeather() {
+        return new MockWeatherService();
+    }
+}
+----
+
+When functions are registered as beans, they are automatically available to the chat model:
 
 [source,java]
 ----
@@ -282,7 +306,7 @@ public class WeatherController {
         UserMessage userMessage = new UserMessage("What's the weather like in " + location + "?");
 
         var promptOptions = WatsonxAiChatOptions.builder()
-            .withFunction("CurrentWeather") // Enable the function
+            .toolName("currentWeather") // Enable the function by bean name
             .build();
 
         ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), promptOptions));
@@ -292,17 +316,264 @@ public class WeatherController {
 }
 ----
 
-Register the function as a bean:
+=== Using ToolCallback for Programmatic Tool Registration
+
+For more programmatic control, use `ToolCallback` and `FunctionToolCallback`. This approach is useful when you need to create tools dynamically at runtime or wrap existing functions:
 
 [source,java]
 ----
-@Configuration
-public class FunctionConfiguration {
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import java.util.function.Function;
 
-    @Bean
-    @Description("Get the weather in location") // function description
-    public Function<MockWeatherService.Request, MockWeatherService.Response> currentWeather() {
-        return new MockWeatherService();
+public class WeatherRequest {
+    private String city;
+    private String unit;
+    
+    // Constructors, getters, setters
+}
+
+public class WeatherResponse {
+    private double temperature;
+    private String unit;
+    private String description;
+    
+    // Constructors, getters, setters
+}
+
+// Define your function
+Function<WeatherRequest, WeatherResponse> weatherFunction =
+    request -> new WeatherResponse(22.0, request.getUnit(), "Sunny");
+
+// Create a ToolCallback
+ToolCallback weatherToolCallback = FunctionToolCallback.builder(
+        "getCurrentWeather",      // Tool name
+        weatherFunction           // The function to execute
+    )
+    .description("Get the current weather for a given city")
+    .inputType(WeatherRequest.class)
+    .build();
+----
+
+=== Using Tools with ChatClient
+
+The `ChatClient` API provides a fluent interface for working with tools:
+
+[source,java]
+----
+@RestController
+public class ChatController {
+
+    private final ChatClient chatClient;
+
+    public ChatController(WatsonxAiChatModel chatModel) {
+        this.chatClient = ChatClient.builder(chatModel).build();
+    }
+
+    @GetMapping("/ai/weather")
+    public String getWeather(@RequestParam String city) {
+        // Using ToolCallback
+        Function<WeatherRequest, WeatherResponse> weatherFn =
+            req -> new WeatherResponse(22.0, req.getUnit(), "Sunny");
+
+        ToolCallback weatherTool = FunctionToolCallback.builder(
+                "getCurrentWeather",
+                weatherFn
+            )
+            .description("Get current weather for a city")
+            .inputType(WeatherRequest.class)
+            .build();
+
+        return chatClient.prompt()
+            .user("What's the weather in " + city + "?")
+            .toolCallbacks(weatherTool)  // Use toolCallbacks() for ToolCallback
+            .call()
+            .content();
     }
 }
+----
+
+==== Specifying Tools by Name
+
+You can also specify which tools to use by their names using the `.toolName()` method. This is useful when you have tools registered as Spring beans and want to selectively enable specific tools for a request:
+
+[source,java]
+----
+@GetMapping("/ai/calculate")
+public String calculate(@RequestParam String question) {
+    return chatClient.prompt()
+        .user(question)
+        .toolName("getCurrentWeather")
+        .toolName("calculateSum")
+        .call()
+        .content();
+}
+----
+
+This approach allows you to:
+
+* Enable specific tools from your registered Spring beans
+* Control which tools are available for each request
+* Combine multiple tools by chaining `.toolName()` calls
+
+=== Using Multiple Tools
+
+The model can intelligently call multiple tools in a single conversation:
+
+[source,java]
+----
+// Create multiple tool callbacks
+ToolCallback weatherTool = FunctionToolCallback.builder(
+        "getCurrentWeather",
+        weatherFunction
+    )
+    .description("Get weather information")
+    .inputType(WeatherRequest.class)
+    .build();
+
+ToolCallback dateTool = FunctionToolCallback.builder(
+        "getCurrentDate",
+        (Void input) -> LocalDate.now().toString()
+    )
+    .description("Get the current date")
+    .build();
+
+String response = chatClient.prompt()
+    .user("What's the weather today in Paris?")
+    .toolCallbacks(weatherTool, dateTool)  // Multiple tools
+    .call()
+    .content();
+----
+
+The model will:
+
+1. Recognize it needs both date and weather information
+2. Call `getCurrentDate()` to get the date
+3. Call `getCurrentWeather()` to get weather data
+4. Combine the results into a coherent response
+
+=== Combining Tools with Response Formats
+
+You can combine tool calling with structured output formats like JSON:
+
+[source,java]
+----
+WatsonxAiChatOptions options = WatsonxAiChatOptions.builder()
+    .model("ibm/granite-3-2b-instruct")
+    .responseFormat(TextChatResponseFormat.jsonObject())
+    .build();
+
+String response = chatClient.prompt()
+    .user("What's the weather like in Paris? Return as JSON.")
+    .toolCallbacks(weatherToolCallback)
+    .options(options)
+    .call()
+    .content();
+
+// Response will be structured JSON:
+// {"city":"Paris","temperature":15.0,"unit":"C","condition":"Cloudy"}
+----
+
+=== Best Practices for Function Calling
+
+==== Provide Clear Descriptions
+
+Clear descriptions help the model understand when to use each tool:
+
+[source,java]
+----
+ToolCallback tool = FunctionToolCallback.builder("getCurrentWeather", weatherFunction)
+    .description("Get the current weather for a specific city. " +
+                 "Requires city name and temperature unit (C or F).")
+    .inputType(WeatherRequest.class)
+    .build();
+----
+
+==== Validate Tool Inputs
+
+Always validate inputs to handle edge cases:
+
+[source,java]
+----
+Function<WeatherRequest, WeatherResponse> weatherFunction = request -> {
+    if (request.getCity() == null || request.getCity().isBlank()) {
+        throw new IllegalArgumentException("City name is required");
+    }
+    
+    if (!List.of("C", "F").contains(request.getUnit())) {
+        throw new IllegalArgumentException("Unit must be C or F");
+    }
+    
+    // Implementation
+    return weatherService.getWeather(request.getCity(), request.getUnit());
+};
+----
+
+==== Handle Errors Gracefully
+
+Implement proper error handling in your tools:
+
+[source,java]
+----
+Function<WeatherRequest, WeatherResponse> weatherFunction = request -> {
+    try {
+        return weatherService.getWeather(request.getCity(), request.getUnit());
+    } catch (Exception e) {
+        logger.error("Failed to get weather", e);
+        return new WeatherResponse(0.0, request.getUnit(), "Weather data unavailable");
+    }
+};
+----
+
+=== Advanced Usage: Dynamic Tool Registration
+
+Create tools dynamically based on runtime conditions:
+
+[source,java]
+----
+@Service
+public class DynamicToolService {
+
+    public List<ToolCallback> createToolsForUser(String userId) {
+        List<ToolCallback> tools = new ArrayList<>();
+        
+        // Add tools based on user permissions
+        if (hasPermission(userId, "weather")) {
+            tools.add(createWeatherTool());
+        }
+        
+        if (hasPermission(userId, "calendar")) {
+            tools.add(createCalendarTool());
+        }
+        
+        return tools;
+    }
+    
+    private ToolCallback createWeatherTool() {
+        return FunctionToolCallback.builder(
+                "getCurrentWeather",
+                weatherFunction
+            )
+            .description("Get weather information")
+            .inputType(WeatherRequest.class)
+            .build();
+    }
+}
+----
+
+=== Tool Execution with Streaming
+
+Tools work seamlessly with streaming responses:
+
+[source,java]
+----
+Flux<ChatResponse> stream = chatClient.prompt()
+    .user("What's the weather in multiple cities?")
+    .toolCallbacks(weatherToolCallback)
+    .stream()
+    .chatResponse();
+
+stream.subscribe(response -> {
+    System.out.println(response.getResult().getOutput().getContent());
+});
 ----


### PR DESCRIPTION
…ck examples

- Add comprehensive overview of function calling mechanism
- Document Spring bean registration with `@Description` annotation
- Add ToolCallback and FunctionToolCallback programmatic examples
- Include ChatClient API usage with .toolCallbacks() method
- Document .toolName() method for selective tool enablement
- Add examples for multiple tools and JSON response formats
- Include best practices for descriptions, validation, and error handling
- Add advanced usage patterns including dynamic tool registration
- Document streaming support with tools
- Remove references to non-existent `@Tool` annotation and `.tools()` method
- Fix incorrect withFunction() to correct toolName() method