### PR TITLE
docs: update all version references from 1.0.0 to 1.X.X across documentation

### DIFF
--- a/docs/src/main/antora/modules/ROOT/pages/chat/index.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/chat/index.adoc
@@ -15,12 +15,14 @@ The following foundation models are supported:
 
 Spring AI provides Spring Boot auto-configuration for the Watsonx.ai Chat Model. To enable it, add the following dependency to your project's Maven `pom.xml` file:
 
+TIP: Check https://central.sonatype.com/search?namespace=org.springaicommunity&name=spring-ai-starter-model-watsonx-ai[Maven Central^] for the latest version.
+
 [source,xml]
 ----
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-starter-model-watsonx-ai</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 
@@ -29,7 +31,7 @@ Or to your Gradle `build.gradle` build file:
 [source,groovy]
 ----
 dependencies {
-    implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.0.0'
+    implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.X.X'
 }
 ----
 
@@ -147,7 +149,7 @@ Add the `spring-ai-watsonx-ai-core` dependency to your project's Maven `pom.xml`
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>watsonx-ai-core</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 

--- a/docs/src/main/antora/modules/ROOT/pages/embeddings/index.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/embeddings/index.adoc
@@ -14,12 +14,14 @@ The following embedding models are supported:
 
 Spring AI provides Spring Boot auto-configuration for the Watsonx.ai Embedding Model. To enable it, add the following dependency to your project's Maven `pom.xml` file:
 
+TIP: Check https://central.sonatype.com/search?namespace=org.springaicommunity&name=spring-ai-starter-model-watsonx-ai[Maven Central^] for the latest version.
+
 [source,xml]
 ----
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-starter-model-watsonx-ai</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 
@@ -28,7 +30,7 @@ Or to your Gradle `build.gradle` build file:
 [source,groovy]
 ----
 dependencies {
-    implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.0.0'
+    implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.X.X'
 }
 ----
 
@@ -117,7 +119,7 @@ Add the `spring-ai-watsonx-ai-core` dependency to your project's Maven `pom.xml`
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>watsonx-ai-core</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 

--- a/docs/src/main/antora/modules/ROOT/pages/getting-started/index.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/getting-started/index.adoc
@@ -33,6 +33,8 @@ Before you begin, ensure you have:
 
 Add the Spring AI Watsonx.ai starter to your project:
 
+TIP: Check https://central.sonatype.com/search?namespace=org.springaicommunity&name=spring-ai-starter-model-watsonx-ai[Maven Central^] for the latest version.
+
 === Maven
 
 Add to your `pom.xml`:
@@ -42,7 +44,7 @@ Add to your `pom.xml`:
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-starter-model-watsonx-ai</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 
@@ -52,7 +54,7 @@ Add to your `build.gradle`:
 
 [source,groovy]
 ----
-implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.0.0'
+implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.X.X'
 ----
 
 == Configure Application

--- a/docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -40,20 +40,22 @@ To use the Watsonx.ai models, you need to:
 
 To get started with Watsonx.ai models in your application, add the following dependency:
 
+TIP: Check https://central.sonatype.com/search?namespace=org.springaicommunity&name=spring-ai-starter-model-watsonx-ai[Maven Central^] for the latest version.
+
 .Maven
 [source,xml]
 ----
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-starter-model-watsonx-ai</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 
 .Gradle
 [source,groovy]
 ----
-implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.0.0'
+implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.X.X'
 ----
 
 Configure your Watsonx.ai credentials in `application.yml`:

--- a/docs/src/main/antora/modules/ROOT/pages/moderation/watsonx-ai-moderation.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/moderation/watsonx-ai-moderation.adoc
@@ -9,12 +9,14 @@ More information about Watsonx.AI guardrails and moderation con be found in http
 
 Spring AI provides Spring Boot auto-configuration for the Watsonx.ai Moderation. To enable it, add the following dependency to your project's Maven `pom.xml` file:
 
+TIP: Check https://central.sonatype.com/search?namespace=org.springaicommunity&name=spring-ai-starter-model-watsonx-ai[Maven Central^] for the latest version.
+
 [source,xml]
 ----
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-starter-model-watsonx-ai</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 
@@ -23,7 +25,7 @@ Or to your Gradle `build.gradle` build file:
 [source,groovy]
 ----
 dependencies {
-    implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.0.0'
+    implementation 'org.springaicommunity:spring-ai-starter-model-watsonx-ai:1.X.X'
 }
 ----
 
@@ -153,7 +155,7 @@ Add the `watsonx-ai-core` dependency to your project's Maven `pom.xml` file:
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>watsonx-ai-core</artifactId>
-    <version>1.0.0</version>
+    <version>1.X.X</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Update all version references from 1.0.0 to 1.X.X across documentation
  - chat/index.adoc
  - embeddings/index.adoc
  - moderation/watsonx-ai-moderation.adoc
  - getting-started/index.adoc
  - index.adoc

- Add Maven Central links for latest version lookup
  - Added TIP sections with link to Maven Central search
  - Helps users find the most current version easily