### PR TITLE
fix: add explicit SCM details to all sub-module POMs

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -30,6 +30,12 @@
     <name>Spring AI Watsonx.ai Documentation</name>
     <description>Spring AI Watsonx.ai Documentation</description>
 
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-watsonx-ai</url>
+        <connection>scm:git:git://github.com/spring-ai-community/spring-ai-watsonx-ai.git</connection>
+        <developerConnection>scm:git:git@github.com:spring-ai-community/spring-ai-watsonx-ai.git</developerConnection>
+    </scm>
+
     <properties>
         <maven-assembly-plugin.version>3.7.0</maven-assembly-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>

--- a/spring-ai-autoconfigure-model-watsonx-ai/pom.xml
+++ b/spring-ai-autoconfigure-model-watsonx-ai/pom.xml
@@ -15,7 +15,13 @@
     <name>Spring AI watsonx.ai Autoconfiguration</name>
     <description>Spring AI watsonx.ai Spring Boot Autoconfiguration</description>
 
-	<dependencies>
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-watsonx-ai</url>
+        <connection>scm:git:git://github.com/spring-ai-community/spring-ai-watsonx-ai.git</connection>
+        <developerConnection>scm:git:git@github.com:spring-ai-community/spring-ai-watsonx-ai.git</developerConnection>
+    </scm>
+
+ <dependencies>
 
 		<!-- Spring AI dependencies -->
 

--- a/spring-ai-starter-model-watsonx-ai/pom.xml
+++ b/spring-ai-starter-model-watsonx-ai/pom.xml
@@ -16,6 +16,12 @@
     <name>Spring AI watsonx.ai Starter</name>
     <description>Spring AI watsonx.ai Spring Boot Starter</description>
 
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-watsonx-ai</url>
+        <connection>scm:git:git://github.com/spring-ai-community/spring-ai-watsonx-ai.git</connection>
+        <developerConnection>scm:git:git@github.com:spring-ai-community/spring-ai-watsonx-ai.git</developerConnection>
+    </scm>
+
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/watsonx-ai-core/pom.xml
+++ b/watsonx-ai-core/pom.xml
@@ -16,6 +16,12 @@
     <name>Spring AI watsonx.ai Core</name>
     <description>watsonx.ai Core Implementation</description>
 
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-watsonx-ai</url>
+        <connection>scm:git:git://github.com/spring-ai-community/spring-ai-watsonx-ai.git</connection>
+        <developerConnection>scm:git:git@github.com:spring-ai-community/spring-ai-watsonx-ai.git</developerConnection>
+    </scm>
+
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Ensures all sub-modules (spring-ai-autoconfigure-model-watsonx-ai, spring-ai-starter-model-watsonx-ai, watsonx-ai-core, and docs) explicitly declare SCM metadata pointing to https://github.com/spring-ai-community/spring-ai-watsonx-ai. This prevents Maven from incorrectly inheriting or generating SCM paths during artifact publishing and releases.