### PR TITLE
chore(deps): add Dependabot config with team reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "spring-ai-community/watsonx-team"
+    pull-request-branch-name:
+      separator: "-"
+  - package-ecosystem: "maven"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "spring-ai-community/watsonx-team"
+    labels:
+      - "dependencies"
+      - "maven"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
Closes #73 

Configure automated dependency updates:
- Maven: daily checks, 10 concurrent PRs
- GitHub Actions: weekly checks
- Auto-assign watsonx-team as reviewers