### PR TITLE
[Feature]: Custom Rerank/Scoring Model and Observation

### DIFF
--- a/docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/docs/src/main/antora/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 * Models
 ** xref:chat/index.adoc[Chat Models]
 ** xref:embeddings/index.adoc[Embedding Models]
+** xref:rerank/index.adoc[Rerank Models]
 ** xref:moderation/watsonx-ai-moderation.adoc[Moderation]
 
 * xref:configuration.adoc[Configuration]

--- a/docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -9,6 +9,7 @@ Watsonx.ai offers several powerful AI models:
 
 * **Chat Models**: Conversational AI models for building intelligent chatbots and assistants
 * **Embedding Models**: Text embedding models for semantic search and similarity analysis
+* **Rerank Models**: Document reranking for improved search relevance in RAG pipelines
 * **Moderation Models**: Content moderation capabilities for safe and responsible AI
 
 == Documentation Navigation
@@ -21,6 +22,7 @@ Explore the complete documentation:
 * **Models**
 ** xref:chat/index.adoc[Chat Models] - Conversational AI capabilities
 ** xref:embeddings/index.adoc[Embedding Models] - Text embedding generation
+** xref:rerank/index.adoc[Rerank Models] - Document reranking for RAG
 ** xref:moderation/watsonx-ai-moderation.adoc[Moderation Models] - Content moderation features
 * xref:configuration.adoc[**Configuration**] - Configure your application
 * xref:samples.adoc[**Sample Applications**] - Ready-to-use sample projects
@@ -106,6 +108,9 @@ The source code for this project is available on GitHub at https://github.com/sp
 
 |xref:embeddings/index.adoc[Embedding Models]
 |Generate text embeddings for semantic search and text similarity analysis
+
+|xref:rerank/index.adoc[Rerank Models]
+|Document reranking for improved search relevance in RAG pipelines
 
 |xref:moderation/watsonx-ai-moderation.adoc[Moderation Models]
 |Content moderation capabilities for safe and responsible AI applications

--- a/docs/src/main/antora/modules/ROOT/pages/rerank/index.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/rerank/index.adoc
@@ -1,0 +1,250 @@
+= Rerank Models
+
+Watsonx.ai Rerank Models provide document reranking capabilities that improve the relevance of search results by scoring and reordering documents based on their semantic relevance to a query. This is particularly useful in Retrieval-Augmented Generation (RAG) pipelines to ensure the most relevant documents are prioritized.
+
+== Overview
+
+Document reranking is a critical step in modern search and RAG systems. While initial retrieval (e.g., vector similarity search) efficiently retrieves candidate documents, reranking uses more sophisticated models to precisely score each document's relevance to the query.
+
+The watsonx.ai rerank integration provides:
+
+* **Standalone Reranking**: Direct API access for scoring and reordering documents
+* **RAG Integration**: `DocumentPostProcessor` implementation for seamless integration with Spring AI's RAG pipeline
+
+== Supported Models
+
+The following rerank models are supported:
+
+* **cross-encoder/ms-marco-minilm-l-12-v2** - A cross-encoder model trained on MS MARCO passage ranking dataset (default)
+* Other reranking models available in your Watsonx.ai instance
+
+== Configuration Properties
+
+=== Rerank Properties
+
+The prefix `spring.ai.watsonx.ai.rerank` is used as the property prefix for configuring the Watsonx.ai rerank model.
+
+[cols="3,5,2"]
+|====
+| Property | Description | Default
+| spring.ai.watsonx.ai.rerank.enabled   | Enable or disable the rerank auto-configuration |  true
+| spring.ai.watsonx.ai.rerank.rerank-endpoint   | The rerank API endpoint |  /ml/v1/text/rerank
+| spring.ai.watsonx.ai.rerank.version    | API version date in YYYY-MM-DD format           |  2024-05-31
+| spring.ai.watsonx.ai.rerank.options.model  | ID of the model to use for reranking | cross-encoder/ms-marco-minilm-l-12-v2
+| spring.ai.watsonx.ai.rerank.options.top-n  | Limit results to top N documents | -
+| spring.ai.watsonx.ai.rerank.options.truncate-input-tokens  | Maximum tokens before truncation | 512
+| spring.ai.watsonx.ai.rerank.options.return-inputs  | Include original text in response | false
+| spring.ai.watsonx.ai.rerank.options.return-query  | Include query in response | false
+|====
+
+== Runtime Options
+
+The https://github.com/spring-ai-community/spring-ai-watsonx-ai/blob/main/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankOptions.java[WatsonxAiRerankOptions.java] class provides options for configuring rerank requests.
+
+On start-up, the options specified by `spring.ai.watsonx.ai.rerank.options` are used, but you can override these at runtime.
+
+[source,java]
+----
+WatsonxAiRerankOptions options = WatsonxAiRerankOptions.builder()
+    .model("cross-encoder/ms-marco-minilm-l-12-v2")
+    .topN(5)
+    .truncateInputTokens(512)
+    .returnInputs(true)
+    .build();
+
+List<RerankResult> results = rerankModel.rerank(query, documents, options);
+----
+
+[[rerank-options]]
+== WatsonxAiRerankOptions
+
+The https://github.com/spring-ai-community/spring-ai-watsonx-ai/blob/main/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankOptions.java[WatsonxAiRerankOptions] class provides various options for configuring rerank requests:
+
+[cols="2,2,4"]
+|====
+|Option |Default |Description
+
+|model
+|cross-encoder/ms-marco-minilm-l-12-v2
+|The rerank model to use
+
+|topN
+|null (return all)
+|Limit results to the top N highest-scoring documents
+
+|truncateInputTokens
+|512
+|Maximum number of tokens per input before truncation
+
+|returnInputs
+|false
+|Whether to include the original input text in the response
+
+|returnQuery
+|false
+|Whether to include the query in the response
+|====
+
+== Standalone Reranking
+
+The `WatsonxAiRerankModel` provides direct access to the reranking API:
+
+[source,java]
+----
+@RestController
+public class RerankController {
+
+    private final WatsonxAiRerankModel rerankModel;
+
+    public RerankController(WatsonxAiRerankModel rerankModel) {
+        this.rerankModel = rerankModel;
+    }
+
+    @PostMapping("/ai/rerank")
+    public List<RerankResult> rerank(
+            @RequestParam String query,
+            @RequestBody List<String> documents) {
+
+        return rerankModel.rerank(query, documents);
+    }
+}
+----
+
+=== Example Response
+
+The rerank API returns results sorted by relevance score (descending):
+
+[source,java]
+----
+List<String> documents = List.of(
+    "Machine learning is a subset of artificial intelligence.",
+    "Cooking Italian pasta requires fresh ingredients.",
+    "Deep learning uses neural networks with many layers."
+);
+
+List<RerankResult> results = rerankModel.rerank(
+    "What is machine learning?",
+    documents
+);
+
+// Results are sorted by score (highest first)
+for (RerankResult result : results) {
+    System.out.println("Index: " + result.index() +
+                       ", Score: " + result.score());
+}
+// Output:
+// Index: 0, Score: 0.95  (Machine learning document)
+// Index: 2, Score: 0.82  (Deep learning document)
+// Index: 1, Score: 0.12  (Cooking document)
+----
+
+== RAG Integration with DocumentPostProcessor
+
+The `WatsonxAiDocumentReranker` implements Spring AI's `DocumentPostProcessor` interface, enabling seamless integration with RAG pipelines.
+
+=== Basic RAG Integration
+
+[source,java]
+----
+@Configuration
+public class RagConfiguration {
+
+    @Bean
+    public RetrievalAugmentationAdvisor retrievalAugmentationAdvisor(
+            VectorStore vectorStore,
+            WatsonxAiDocumentReranker documentReranker) {
+
+        return RetrievalAugmentationAdvisor.builder()
+            .documentRetriever(VectorStoreDocumentRetriever.builder()
+                .vectorStore(vectorStore)
+                .similarityThreshold(0.5)
+                .topK(20)  // Retrieve more candidates for reranking
+                .build())
+            .documentPostProcessors(documentReranker)  // Rerank the results
+            .build();
+    }
+}
+----
+
+=== Using with ChatClient
+
+[source,java]
+----
+@Service
+public class RagService {
+
+    private final ChatClient chatClient;
+
+    public RagService(
+            ChatModel chatModel,
+            VectorStore vectorStore,
+            WatsonxAiDocumentReranker documentReranker) {
+
+        RetrievalAugmentationAdvisor advisor = RetrievalAugmentationAdvisor.builder()
+            .documentRetriever(VectorStoreDocumentRetriever.builder()
+                .vectorStore(vectorStore)
+                .topK(20)
+                .build())
+            .documentPostProcessors(documentReranker)
+            .build();
+
+        this.chatClient = ChatClient.builder(chatModel)
+            .defaultAdvisors(advisor)
+            .build();
+    }
+
+    public String ask(String question) {
+        return chatClient.prompt()
+            .user(question)
+            .call()
+            .content();
+    }
+}
+----
+
+=== Custom Reranker Configuration
+
+You can create a reranker with custom options:
+
+[source,java]
+----
+@Bean
+public WatsonxAiDocumentReranker customDocumentReranker(
+        WatsonxAiRerankModel rerankModel) {
+
+    WatsonxAiRerankOptions options = WatsonxAiRerankOptions.builder()
+        .topN(5)  // Return only top 5 documents
+        .truncateInputTokens(1024)
+        .build();
+
+    return new WatsonxAiDocumentReranker(rerankModel, options);
+}
+----
+
+=== Accessing Rerank Scores
+
+When documents are reranked, the rerank score is stored in the document's metadata:
+
+[source,java]
+----
+// After reranking, documents have the score in metadata
+List<Document> rerankedDocs = documentReranker.process(query, documents);
+
+for (Document doc : rerankedDocs) {
+    Double rerankScore = (Double) doc.getMetadata()
+        .get(WatsonxAiDocumentReranker.RERANK_SCORE_METADATA_KEY);
+
+    System.out.println("Document: " + doc.getId() +
+                       ", Rerank Score: " + rerankScore);
+}
+----
+
+For RAG integration, also add the Spring AI RAG dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-rag</artifactId>
+</dependency>
+----

--- a/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springaicommunity/watsonx/autoconfigure/rerank/WatsonxAiRerankAutoConfiguration.java
+++ b/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springaicommunity/watsonx/autoconfigure/rerank/WatsonxAiRerankAutoConfiguration.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.autoconfigure.rerank;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.springaicommunity.watsonx.autoconfigure.WatsonxAiConnectionProperties;
+import org.springaicommunity.watsonx.rerank.WatsonxAiDocumentReranker;
+import org.springaicommunity.watsonx.rerank.WatsonxAiRerankApi;
+import org.springaicommunity.watsonx.rerank.WatsonxAiRerankModel;
+import org.springaicommunity.watsonx.rerank.observation.RerankModelObservationConvention;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Auto-configures watsonx.ai rerank services as part of Spring AI.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+@AutoConfiguration(
+    after = {RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class})
+@ConditionalOnClass(WatsonxAiRerankApi.class)
+@ConditionalOnProperty(
+    prefix = WatsonxAiRerankProperties.CONFIG_PREFIX,
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@EnableConfigurationProperties({
+  WatsonxAiConnectionProperties.class,
+  WatsonxAiRerankProperties.class
+})
+@ImportAutoConfiguration(
+    classes = {SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class})
+public class WatsonxAiRerankAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public WatsonxAiRerankApi watsonxAiRerankApi(
+      final WatsonxAiConnectionProperties connectionProperties,
+      final WatsonxAiRerankProperties rerankProperties,
+      final ObjectProvider<RestClient.Builder> restClientObjectProvider,
+      ResponseErrorHandler responseErrorHandler) {
+
+    return new WatsonxAiRerankApi(
+        connectionProperties.getBaseUrl(),
+        rerankProperties.getRerankEndpoint(),
+        rerankProperties.getVersion(),
+        connectionProperties.getProjectId(),
+        connectionProperties.getSpaceId(),
+        connectionProperties.getApiKey(),
+        restClientObjectProvider.getIfAvailable(RestClient::builder),
+        responseErrorHandler);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public WatsonxAiRerankModel watsonxAiRerankModel(
+      WatsonxAiRerankApi watsonxAiRerankApi,
+      WatsonxAiRerankProperties rerankProperties,
+      ObjectProvider<ObservationRegistry> observationRegistry,
+      RetryTemplate retryTemplate,
+      ObjectProvider<RerankModelObservationConvention> observationConvention) {
+
+    var watsonxAiRerankModel =
+        new WatsonxAiRerankModel(
+            watsonxAiRerankApi,
+            rerankProperties.getOptions(),
+            observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
+            retryTemplate);
+
+    observationConvention.ifUnique(watsonxAiRerankModel::setObservationConvention);
+
+    return watsonxAiRerankModel;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public WatsonxAiDocumentReranker watsonxAiDocumentReranker(
+      WatsonxAiRerankModel watsonxAiRerankModel) {
+    return new WatsonxAiDocumentReranker(watsonxAiRerankModel);
+  }
+}

--- a/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springaicommunity/watsonx/autoconfigure/rerank/WatsonxAiRerankProperties.java
+++ b/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springaicommunity/watsonx/autoconfigure/rerank/WatsonxAiRerankProperties.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.autoconfigure.rerank;
+
+import org.springaicommunity.watsonx.rerank.WatsonxAiRerankOptions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for watsonx.ai Rerank Model.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+@ConfigurationProperties(WatsonxAiRerankProperties.CONFIG_PREFIX)
+public class WatsonxAiRerankProperties {
+
+  public static final String CONFIG_PREFIX = "spring.ai.watsonx.ai.rerank";
+
+  /** Enable or disable the watsonx.ai Rerank auto-configuration. */
+  private boolean enabled = true;
+
+  /** The endpoint for the rerank API. */
+  private String rerankEndpoint = "/ml/v1/text/rerank";
+
+  /**
+   * API version date to use, in YYYY-MM-DD format. Example: 2024-05-31. See the <a
+   * href="https://cloud.ibm.com/apidocs/watsonx-ai#api-versioning">watsonx.ai API versioning</a>
+   */
+  private String version = "2024-05-31";
+
+  /**
+   * The default options to use when calling the watsonx.ai Rerank API. These can be overridden by
+   * passing options in the request.
+   */
+  @NestedConfigurationProperty
+  private WatsonxAiRerankOptions options =
+      WatsonxAiRerankOptions.builder()
+          .model("cross-encoder/ms-marco-minilm-l-12-v2")
+          .truncateInputTokens(512)
+          .build();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getRerankEndpoint() {
+    return rerankEndpoint;
+  }
+
+  public void setRerankEndpoint(String rerankEndpoint) {
+    this.rerankEndpoint = rerankEndpoint;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public WatsonxAiRerankOptions getOptions() {
+    return options;
+  }
+
+  public void setOptions(WatsonxAiRerankOptions options) {
+    this.options = options;
+  }
+}

--- a/spring-ai-autoconfigure-model-watsonx-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-autoconfigure-model-watsonx-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -16,3 +16,4 @@
 org.springaicommunity.watsonx.autoconfigure.chat.WatsonxAiChatAutoConfiguration
 org.springaicommunity.watsonx.autoconfigure.embedding.WatsonxAiEmbeddingAutoConfiguration
 org.springaicommunity.watsonx.autoconfigure.moderation.WatsonxAiModerationAutoConfiguration
+org.springaicommunity.watsonx.autoconfigure.rerank.WatsonxAiRerankAutoConfiguration

--- a/watsonx-ai-core/pom.xml
+++ b/watsonx-ai-core/pom.xml
@@ -37,6 +37,12 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-retry</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-rag</artifactId>
+            <optional>true</optional>
+        </dependency>
         
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiDocumentReranker.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiDocumentReranker.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+import org.springframework.ai.rag.postretrieval.document.DocumentPostProcessor;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * A {@link DocumentPostProcessor} implementation that uses watsonx.ai reranking to reorder
+ * documents based on their relevance to the query.
+ *
+ * <p>This can be used in a RAG pipeline with {@code RetrievalAugmentationAdvisor} to improve the
+ * quality of retrieved documents by reranking them based on semantic relevance.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public class WatsonxAiDocumentReranker implements DocumentPostProcessor {
+
+  private static final Logger logger = LoggerFactory.getLogger(WatsonxAiDocumentReranker.class);
+
+  public static final String RERANK_SCORE_METADATA_KEY = "rerank_score";
+
+  private final WatsonxAiRerankModel rerankModel;
+  private final WatsonxAiRerankOptions options;
+
+  /**
+   * Create a new WatsonxAiDocumentReranker with default options.
+   *
+   * @param rerankModel the rerank model to use
+   */
+  public WatsonxAiDocumentReranker(WatsonxAiRerankModel rerankModel) {
+    this(rerankModel, null);
+  }
+
+  /**
+   * Create a new WatsonxAiDocumentReranker with custom options.
+   *
+   * @param rerankModel the rerank model to use
+   * @param options optional rerank options to override defaults
+   */
+  public WatsonxAiDocumentReranker(
+      WatsonxAiRerankModel rerankModel, WatsonxAiRerankOptions options) {
+    Assert.notNull(rerankModel, "WatsonxAiRerankModel must not be null");
+    this.rerankModel = rerankModel;
+    this.options = options;
+  }
+
+  @Override
+  public List<Document> process(Query query, List<Document> documents) {
+    Assert.notNull(query, "Query must not be null");
+
+    if (CollectionUtils.isEmpty(documents)) {
+      logger.debug("No documents to rerank, returning empty list");
+      return List.of();
+    }
+
+    logger.debug("Reranking {} documents for query: {}", documents.size(), query.text());
+
+    List<String> documentTexts = documents.stream().map(Document::getText).toList();
+
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        this.rerankModel.rerank(query.text(), documentTexts, this.options);
+
+    if (CollectionUtils.isEmpty(results)) {
+      logger.warn("Rerank API returned no results, returning original documents");
+      return documents;
+    }
+
+    List<Document> rerankedDocuments = new ArrayList<>(results.size());
+    for (WatsonxAiRerankResponse.RerankResult result : results) {
+      int originalIndex = result.index();
+      if (originalIndex >= 0 && originalIndex < documents.size()) {
+        Document originalDocument = documents.get(originalIndex);
+
+        Map<String, Object> updatedMetadata = new HashMap<>(originalDocument.getMetadata());
+        updatedMetadata.put(RERANK_SCORE_METADATA_KEY, result.score());
+
+        Document rerankedDocument =
+            Document.builder()
+                .id(originalDocument.getId())
+                .text(originalDocument.getText())
+                .metadata(updatedMetadata)
+                .score(result.score())
+                .build();
+
+        rerankedDocuments.add(rerankedDocument);
+      } else {
+        logger.warn("Rerank result index {} is out of bounds, skipping", originalIndex);
+      }
+    }
+
+    logger.debug("Reranked {} documents", rerankedDocuments.size());
+    return rerankedDocuments;
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankApi.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankApi.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.springaicommunity.watsonx.auth.WatsonxAiAuthentication;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+/**
+ * API implementation of watsonx.ai Rerank Model API.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public class WatsonxAiRerankApi {
+
+  private final RestClient restClient;
+  private final WatsonxAiAuthentication watsonxAiAuthentication;
+  private final String rerankEndpoint;
+  private final String projectId;
+  private final String spaceId;
+  private final String version;
+
+  public WatsonxAiRerankApi(
+      final String baseUrl,
+      final String rerankEndpoint,
+      final String version,
+      final String projectId,
+      final String spaceId,
+      final String apiKey,
+      final RestClient.Builder restClientBuilder,
+      final ResponseErrorHandler responseErrorHandler) {
+
+    this.rerankEndpoint = rerankEndpoint;
+    this.version = version;
+    this.projectId = projectId;
+    this.spaceId = spaceId;
+    this.watsonxAiAuthentication = new WatsonxAiAuthentication(apiKey);
+
+    final Consumer<HttpHeaders> defaultHeaders =
+        headers -> {
+          headers.setContentType(MediaType.APPLICATION_JSON);
+          headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        };
+
+    this.restClient =
+        restClientBuilder
+            .baseUrl(baseUrl)
+            .defaultStatusHandler(responseErrorHandler)
+            .defaultHeaders(defaultHeaders)
+            .build();
+  }
+
+  /**
+   * Synchronous call to watsonx.ai Rerank API.
+   *
+   * @param watsonxAiRerankRequest the watsonx.ai rerank request
+   * @return the response entity containing the watsonx.ai rerank response
+   */
+  public ResponseEntity<WatsonxAiRerankResponse> rerank(
+      final WatsonxAiRerankRequest watsonxAiRerankRequest) {
+    Assert.notNull(watsonxAiRerankRequest, "Watsonx.ai rerank request cannot be null");
+
+    return restClient
+        .post()
+        .uri(
+            uriBuilder ->
+                uriBuilder.path(this.rerankEndpoint).queryParam("version", this.version).build())
+        .header(
+            HttpHeaders.AUTHORIZATION, "Bearer " + this.watsonxAiAuthentication.getAccessToken())
+        .body(watsonxAiRerankRequest.toBuilder().projectId(projectId).spaceId(spaceId).build())
+        .retrieve()
+        .toEntity(WatsonxAiRerankResponse.class);
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankModel.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankModel.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import io.micrometer.observation.ObservationRegistry;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.watsonx.rerank.observation.DefaultRerankModelObservationConvention;
+import org.springaicommunity.watsonx.rerank.observation.RerankModelObservationContext;
+import org.springaicommunity.watsonx.rerank.observation.RerankModelObservationConvention;
+import org.springaicommunity.watsonx.rerank.observation.RerankModelObservationDocumentation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Rerank model implementation that provides access to watsonx.ai supported reranking models.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public class WatsonxAiRerankModel {
+
+  private static final Logger logger = LoggerFactory.getLogger(WatsonxAiRerankModel.class);
+
+  private static final RerankModelObservationConvention DEFAULT_OBSERVATION_CONVENTION =
+      new DefaultRerankModelObservationConvention();
+
+  private static final String PROVIDER = "watsonx-ai";
+
+  private final WatsonxAiRerankApi watsonxAiRerankApi;
+  private final WatsonxAiRerankOptions defaultOptions;
+  private final RetryTemplate retryTemplate;
+  private final ObservationRegistry observationRegistry;
+  private RerankModelObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
+
+  public WatsonxAiRerankModel(
+      WatsonxAiRerankApi watsonxAiRerankApi,
+      WatsonxAiRerankOptions defaultOptions,
+      ObservationRegistry observationRegistry,
+      RetryTemplate retryTemplate) {
+    Assert.notNull(watsonxAiRerankApi, "WatsonxAiRerankApi must not be null");
+    Assert.notNull(defaultOptions, "WatsonxAiRerankOptions must not be null");
+    Assert.notNull(observationRegistry, "ObservationRegistry must not be null");
+    Assert.notNull(retryTemplate, "RetryTemplate must not be null");
+    this.watsonxAiRerankApi = watsonxAiRerankApi;
+    this.defaultOptions = defaultOptions;
+    this.observationRegistry = observationRegistry;
+    this.retryTemplate = retryTemplate;
+  }
+
+  /**
+   * Rerank documents based on their relevance to the query using the default options.
+   *
+   * @param query the query string to rank against
+   * @param documents the list of document texts to rerank
+   * @return list of rerank results sorted by relevance score (descending)
+   */
+  public List<WatsonxAiRerankResponse.RerankResult> rerank(String query, List<String> documents) {
+    return rerank(query, documents, null);
+  }
+
+  /**
+   * Rerank documents based on their relevance to the query.
+   *
+   * @param query the query string to rank against
+   * @param documents the list of document texts to rerank
+   * @param runtimeOptions optional runtime options to override defaults
+   * @return list of rerank results sorted by relevance score (descending)
+   */
+  public List<WatsonxAiRerankResponse.RerankResult> rerank(
+      String query, List<String> documents, WatsonxAiRerankOptions runtimeOptions) {
+    Assert.hasText(query, "Query must not be null or empty");
+    Assert.notEmpty(documents, "Documents must not be empty");
+
+    WatsonxAiRerankOptions mergedOptions = mergeOptions(runtimeOptions);
+
+    RerankModelObservationContext observationContext =
+        RerankModelObservationContext.builder()
+            .query(query)
+            .documentCount(documents.size())
+            .options(mergedOptions)
+            .provider(PROVIDER)
+            .build();
+
+    return RerankModelObservationDocumentation.RERANK_MODEL_OPERATION
+        .observation(
+            this.observationConvention,
+            DEFAULT_OBSERVATION_CONVENTION,
+            () -> observationContext,
+            this.observationRegistry)
+        .observe(
+            () -> {
+              WatsonxAiRerankResponse response =
+                  this.retryTemplate.execute(
+                      ctx -> {
+                        List<WatsonxAiRerankRequest.RerankInput> inputs =
+                            documents.stream().map(WatsonxAiRerankRequest.RerankInput::of).toList();
+
+                        WatsonxAiRerankRequest.RerankReturnOptions returnOptions =
+                            WatsonxAiRerankRequest.RerankReturnOptions.of(
+                                mergedOptions.getTopN(),
+                                mergedOptions.getReturnInputs(),
+                                mergedOptions.getReturnQuery());
+
+                        WatsonxAiRerankRequest.RerankParameters parameters =
+                            WatsonxAiRerankRequest.RerankParameters.of(
+                                mergedOptions.getTruncateInputTokens(), returnOptions);
+
+                        WatsonxAiRerankRequest request =
+                            WatsonxAiRerankRequest.builder()
+                                .model(mergedOptions.getModel())
+                                .inputs(inputs)
+                                .query(query)
+                                .parameters(parameters)
+                                .build();
+
+                        ResponseEntity<WatsonxAiRerankResponse> apiResponse =
+                            this.watsonxAiRerankApi.rerank(request);
+
+                        return apiResponse.getBody();
+                      });
+
+              if (response == null || CollectionUtils.isEmpty(response.results())) {
+                return List.of();
+              }
+
+              observationContext.setResponse(response);
+              return response.results();
+            });
+  }
+
+  private WatsonxAiRerankOptions mergeOptions(WatsonxAiRerankOptions runtimeOptions) {
+    WatsonxAiRerankOptions.Builder builder = this.defaultOptions.toBuilder();
+
+    if (runtimeOptions != null) {
+      if (runtimeOptions.getModel() != null) {
+        builder.model(runtimeOptions.getModel());
+      }
+      if (runtimeOptions.getTopN() != null) {
+        builder.topN(runtimeOptions.getTopN());
+      }
+      if (runtimeOptions.getTruncateInputTokens() != null) {
+        builder.truncateInputTokens(runtimeOptions.getTruncateInputTokens());
+      }
+      if (runtimeOptions.getReturnInputs() != null) {
+        builder.returnInputs(runtimeOptions.getReturnInputs());
+      }
+      if (runtimeOptions.getReturnQuery() != null) {
+        builder.returnQuery(runtimeOptions.getReturnQuery());
+      }
+    }
+
+    return builder.build();
+  }
+
+  public WatsonxAiRerankOptions getDefaultOptions() {
+    return this.defaultOptions;
+  }
+
+  public void setObservationConvention(RerankModelObservationConvention observationConvention) {
+    Assert.notNull(observationConvention, "observationConvention must not be null");
+    this.observationConvention = observationConvention;
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankOptions.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankOptions.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import org.springframework.ai.model.ModelOptionsUtils;
+
+/**
+ * Options for watsonx.ai Rerank API. Configuration options that can be passed to control the
+ * behavior of the rerank model.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WatsonxAiRerankOptions {
+
+  @JsonProperty("model_id")
+  private String model;
+
+  @JsonProperty("top_n")
+  private Integer topN;
+
+  @JsonProperty("truncate_input_tokens")
+  private Integer truncateInputTokens;
+
+  @JsonProperty("return_inputs")
+  private Boolean returnInputs;
+
+  @JsonProperty("return_query")
+  private Boolean returnQuery;
+
+  public WatsonxAiRerankOptions() {}
+
+  private WatsonxAiRerankOptions(Builder builder) {
+    this.model = builder.model;
+    this.topN = builder.topN;
+    this.truncateInputTokens = builder.truncateInputTokens;
+    this.returnInputs = builder.returnInputs;
+    this.returnQuery = builder.returnQuery;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public void setModel(String model) {
+    this.model = model;
+  }
+
+  public Integer getTopN() {
+    return topN;
+  }
+
+  public void setTopN(Integer topN) {
+    this.topN = topN;
+  }
+
+  public Integer getTruncateInputTokens() {
+    return truncateInputTokens;
+  }
+
+  public void setTruncateInputTokens(Integer truncateInputTokens) {
+    this.truncateInputTokens = truncateInputTokens;
+  }
+
+  public Boolean getReturnInputs() {
+    return returnInputs;
+  }
+
+  public void setReturnInputs(Boolean returnInputs) {
+    this.returnInputs = returnInputs;
+  }
+
+  public Boolean getReturnQuery() {
+    return returnQuery;
+  }
+
+  public void setReturnQuery(Boolean returnQuery) {
+    this.returnQuery = returnQuery;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder()
+        .model(this.model)
+        .topN(this.topN)
+        .truncateInputTokens(this.truncateInputTokens)
+        .returnInputs(this.returnInputs)
+        .returnQuery(this.returnQuery);
+  }
+
+  public WatsonxAiRerankOptions copy() {
+    return toBuilder().build();
+  }
+
+  @Override
+  public String toString() {
+    return "WatsonxAiRerankOptions: " + ModelOptionsUtils.toJsonString(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WatsonxAiRerankOptions other = (WatsonxAiRerankOptions) o;
+    return Objects.equals(this.model, other.model)
+        && Objects.equals(this.topN, other.topN)
+        && Objects.equals(this.truncateInputTokens, other.truncateInputTokens)
+        && Objects.equals(this.returnInputs, other.returnInputs)
+        && Objects.equals(this.returnQuery, other.returnQuery);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        this.model, this.topN, this.truncateInputTokens, this.returnInputs, this.returnQuery);
+  }
+
+  public static class Builder {
+    private String model;
+    private Integer topN;
+    private Integer truncateInputTokens;
+    private Boolean returnInputs;
+    private Boolean returnQuery;
+
+    private Builder() {}
+
+    public Builder model(String model) {
+      this.model = model;
+      return this;
+    }
+
+    public Builder topN(Integer topN) {
+      this.topN = topN;
+      return this;
+    }
+
+    public Builder truncateInputTokens(Integer truncateInputTokens) {
+      this.truncateInputTokens = truncateInputTokens;
+      return this;
+    }
+
+    public Builder returnInputs(Boolean returnInputs) {
+      this.returnInputs = returnInputs;
+      return this;
+    }
+
+    public Builder returnQuery(Boolean returnQuery) {
+      this.returnQuery = returnQuery;
+      return this;
+    }
+
+    public WatsonxAiRerankOptions build() {
+      return new WatsonxAiRerankOptions(this);
+    }
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankRequest.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankRequest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Request for the watsonx.ai Rerank API. Full documentation can be found at <a
+ * href="https://cloud.ibm.com/apidocs/watsonx-ai#text-rerank">watsonx.ai Text Rerank</a>.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class WatsonxAiRerankRequest {
+
+  @JsonProperty("model_id")
+  private String model;
+
+  @JsonProperty("project_id")
+  private String projectId;
+
+  @JsonProperty("space_id")
+  private String spaceId;
+
+  @JsonProperty("inputs")
+  private List<RerankInput> inputs;
+
+  @JsonProperty("query")
+  private String query;
+
+  @JsonProperty("parameters")
+  private RerankParameters parameters;
+
+  public WatsonxAiRerankRequest() {}
+
+  private WatsonxAiRerankRequest(Builder builder) {
+    this.model = builder.model;
+    this.projectId = builder.projectId;
+    this.spaceId = builder.spaceId;
+    this.inputs = builder.inputs;
+    this.query = builder.query;
+    this.parameters = builder.parameters;
+  }
+
+  public String model() {
+    return model;
+  }
+
+  public String projectId() {
+    return projectId;
+  }
+
+  public String spaceId() {
+    return spaceId;
+  }
+
+  public List<RerankInput> inputs() {
+    return inputs;
+  }
+
+  public String query() {
+    return query;
+  }
+
+  public RerankParameters parameters() {
+    return parameters;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder()
+        .model(this.model)
+        .projectId(this.projectId)
+        .spaceId(this.spaceId)
+        .inputs(this.inputs)
+        .query(this.query)
+        .parameters(this.parameters);
+  }
+
+  public static class Builder {
+    private String model;
+    private String projectId;
+    private String spaceId;
+    private List<RerankInput> inputs;
+    private String query;
+    private RerankParameters parameters;
+
+    private Builder() {}
+
+    public Builder model(String model) {
+      this.model = model;
+      return this;
+    }
+
+    public Builder projectId(String projectId) {
+      this.projectId = projectId;
+      return this;
+    }
+
+    public Builder spaceId(String spaceId) {
+      this.spaceId = spaceId;
+      return this;
+    }
+
+    public Builder inputs(List<RerankInput> inputs) {
+      this.inputs = inputs;
+      return this;
+    }
+
+    public Builder query(String query) {
+      this.query = query;
+      return this;
+    }
+
+    public Builder parameters(RerankParameters parameters) {
+      this.parameters = parameters;
+      return this;
+    }
+
+    public WatsonxAiRerankRequest build() {
+      return new WatsonxAiRerankRequest(this);
+    }
+  }
+
+  /** Represents an input document for reranking. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record RerankInput(@JsonProperty("text") String text) {
+
+    public static RerankInput of(String text) {
+      return new RerankInput(text);
+    }
+  }
+
+  /** Parameters for the rerank request. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record RerankParameters(
+      @JsonProperty("truncate_input_tokens") Integer truncateInputTokens,
+      @JsonProperty("return_options") RerankReturnOptions returnOptions) {
+
+    public static RerankParameters of(
+        Integer truncateInputTokens, RerankReturnOptions returnOptions) {
+      return new RerankParameters(truncateInputTokens, returnOptions);
+    }
+  }
+
+  /** Return options for the rerank response. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record RerankReturnOptions(
+      @JsonProperty("top_n") Integer topN,
+      @JsonProperty("inputs") Boolean inputs,
+      @JsonProperty("query") Boolean query) {
+
+    public static RerankReturnOptions of(Integer topN, Boolean inputs, Boolean query) {
+      return new RerankReturnOptions(topN, inputs, query);
+    }
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankResponse.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankResponse.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Response from the watsonx.ai Rerank API. Full documentation can be found at <a
+ * href="https://cloud.ibm.com/apidocs/watsonx-ai#text-rerank">watsonx.ai Text Rerank</a>.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record WatsonxAiRerankResponse(
+    @JsonProperty("model_id") String model,
+    @JsonProperty("model_version") String modelVersion,
+    @JsonProperty("results") List<RerankResult> results,
+    @JsonProperty("created_at") LocalDateTime createdAt,
+    @JsonProperty("input_token_count") Integer inputTokenCount,
+    @JsonProperty("query") String query) {
+
+  /** Individual rerank result containing the document index and relevance score. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record RerankResult(
+      @JsonProperty("index") Integer index,
+      @JsonProperty("score") Double score,
+      @JsonProperty("input") RerankInputResult input) {}
+
+  /** The input text returned when return_options.inputs is true. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record RerankInputResult(@JsonProperty("text") String text) {}
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/DefaultRerankModelObservationConvention.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/DefaultRerankModelObservationConvention.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank.observation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import java.util.Optional;
+import org.springframework.util.StringUtils;
+
+/**
+ * Default conventions to populate observations for rerank model operations.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public class DefaultRerankModelObservationConvention implements RerankModelObservationConvention {
+
+  public static final String DEFAULT_NAME = "gen_ai.client.operation";
+
+  private static final KeyValue REQUEST_MODEL_NONE =
+      KeyValue.of(
+          RerankModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL,
+          KeyValue.NONE_VALUE);
+
+  private static final KeyValue RESPONSE_MODEL_NONE =
+      KeyValue.of(
+          RerankModelObservationDocumentation.LowCardinalityKeyNames.RESPONSE_MODEL,
+          KeyValue.NONE_VALUE);
+
+  @Override
+  public String getName() {
+    return DEFAULT_NAME;
+  }
+
+  @Override
+  public String getContextualName(RerankModelObservationContext context) {
+    return Optional.ofNullable(context.getOptions())
+        .map(options -> options.getModel())
+        .filter(StringUtils::hasText)
+        .map(model -> "%s %s".formatted(context.getOperationMetadata().operationType(), model))
+        .orElseGet(() -> context.getOperationMetadata().operationType());
+  }
+
+  @Override
+  public KeyValues getLowCardinalityKeyValues(RerankModelObservationContext context) {
+    return KeyValues.of(
+        aiOperationType(context),
+        aiProvider(context),
+        requestModel(context),
+        responseModel(context));
+  }
+
+  protected KeyValue aiOperationType(RerankModelObservationContext context) {
+    return KeyValue.of(
+        RerankModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE,
+        context.getOperationMetadata().operationType());
+  }
+
+  protected KeyValue aiProvider(RerankModelObservationContext context) {
+    return KeyValue.of(
+        RerankModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER,
+        context.getOperationMetadata().provider());
+  }
+
+  protected KeyValue requestModel(RerankModelObservationContext context) {
+    return Optional.ofNullable(context.getOptions())
+        .map(options -> options.getModel())
+        .filter(StringUtils::hasText)
+        .map(
+            model ->
+                KeyValue.of(
+                    RerankModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL,
+                    model))
+        .orElse(REQUEST_MODEL_NONE);
+  }
+
+  protected KeyValue responseModel(RerankModelObservationContext context) {
+    return Optional.ofNullable(context.getResponse())
+        .map(response -> response.model())
+        .filter(StringUtils::hasText)
+        .map(
+            model ->
+                KeyValue.of(
+                    RerankModelObservationDocumentation.LowCardinalityKeyNames.RESPONSE_MODEL,
+                    model))
+        .orElse(RESPONSE_MODEL_NONE);
+  }
+
+  @Override
+  public KeyValues getHighCardinalityKeyValues(RerankModelObservationContext context) {
+    var keyValues = KeyValues.empty();
+    keyValues = documentCount(keyValues, context);
+    keyValues = topN(keyValues, context);
+    keyValues = inputTokenCount(keyValues, context);
+    return keyValues;
+  }
+
+  protected KeyValues documentCount(KeyValues keyValues, RerankModelObservationContext context) {
+    return keyValues.and(
+        RerankModelObservationDocumentation.HighCardinalityKeyNames.DOCUMENT_COUNT.asString(),
+        String.valueOf(context.getDocumentCount()));
+  }
+
+  protected KeyValues topN(KeyValues keyValues, RerankModelObservationContext context) {
+    return Optional.ofNullable(context.getOptions())
+        .map(options -> options.getTopN())
+        .map(
+            topN ->
+                keyValues.and(
+                    RerankModelObservationDocumentation.HighCardinalityKeyNames.TOP_N.asString(),
+                    String.valueOf(topN)))
+        .orElse(keyValues);
+  }
+
+  protected KeyValues inputTokenCount(KeyValues keyValues, RerankModelObservationContext context) {
+    return Optional.ofNullable(context.getResponse())
+        .map(response -> response.inputTokenCount())
+        .map(
+            inputTokenCount ->
+                keyValues.and(
+                    RerankModelObservationDocumentation.HighCardinalityKeyNames.USAGE_INPUT_TOKENS
+                        .asString(),
+                    String.valueOf(inputTokenCount)))
+        .orElse(keyValues);
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/RerankModelObservationContext.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/RerankModelObservationContext.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank.observation;
+
+import io.micrometer.observation.Observation;
+import org.springaicommunity.watsonx.rerank.WatsonxAiRerankOptions;
+import org.springaicommunity.watsonx.rerank.WatsonxAiRerankResponse;
+import org.springframework.ai.observation.AiOperationMetadata;
+import org.springframework.util.Assert;
+
+/**
+ * Context used to store metadata for rerank model exchanges.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public class RerankModelObservationContext extends Observation.Context {
+
+  public static final String OPERATION_TYPE = "rerank";
+
+  private final String query;
+  private final int documentCount;
+  private final WatsonxAiRerankOptions options;
+  private final AiOperationMetadata operationMetadata;
+  private WatsonxAiRerankResponse response;
+
+  RerankModelObservationContext(
+      String query, int documentCount, WatsonxAiRerankOptions options, String provider) {
+    this.query = query;
+    this.documentCount = documentCount;
+    this.options = options;
+    this.operationMetadata =
+        AiOperationMetadata.builder().operationType(OPERATION_TYPE).provider(provider).build();
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public int getDocumentCount() {
+    return documentCount;
+  }
+
+  public WatsonxAiRerankOptions getOptions() {
+    return options;
+  }
+
+  public AiOperationMetadata getOperationMetadata() {
+    return operationMetadata;
+  }
+
+  public WatsonxAiRerankResponse getResponse() {
+    return response;
+  }
+
+  public void setResponse(WatsonxAiRerankResponse response) {
+    Assert.notNull(response, "response cannot be null");
+    this.response = response;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private String query;
+    private int documentCount;
+    private WatsonxAiRerankOptions options;
+    private String provider;
+
+    private Builder() {}
+
+    public Builder query(String query) {
+      this.query = query;
+      return this;
+    }
+
+    public Builder documentCount(int documentCount) {
+      this.documentCount = documentCount;
+      return this;
+    }
+
+    public Builder options(WatsonxAiRerankOptions options) {
+      this.options = options;
+      return this;
+    }
+
+    public Builder provider(String provider) {
+      this.provider = provider;
+      return this;
+    }
+
+    public RerankModelObservationContext build() {
+      Assert.hasText(this.query, "query cannot be null or empty");
+      Assert.notNull(this.options, "options cannot be null");
+      Assert.hasText(this.provider, "provider cannot be null or empty");
+      return new RerankModelObservationContext(
+          this.query, this.documentCount, this.options, this.provider);
+    }
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/RerankModelObservationConvention.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/RerankModelObservationConvention.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank.observation;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+
+/**
+ * Interface for an {@link ObservationConvention} for rerank model exchanges.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public interface RerankModelObservationConvention
+    extends ObservationConvention<RerankModelObservationContext> {
+
+  @Override
+  default boolean supportsContext(Observation.Context context) {
+    return context instanceof RerankModelObservationContext;
+  }
+}

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/RerankModelObservationDocumentation.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/rerank/observation/RerankModelObservationDocumentation.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank.observation;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+
+/**
+ * Documented conventions for rerank model observations.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public enum RerankModelObservationDocumentation implements ObservationDocumentation {
+  RERANK_MODEL_OPERATION {
+    @Override
+    public Class<? extends ObservationConvention<? extends Observation.Context>>
+        getDefaultConvention() {
+      return DefaultRerankModelObservationConvention.class;
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return LowCardinalityKeyNames.values();
+    }
+
+    @Override
+    public KeyName[] getHighCardinalityKeyNames() {
+      return HighCardinalityKeyNames.values();
+    }
+  };
+
+  /** Low-cardinality observation key names for rerank model operations. */
+  public enum LowCardinalityKeyNames implements KeyName {
+    AI_OPERATION_TYPE {
+      @Override
+      public String asString() {
+        return AiObservationAttributes.AI_OPERATION_TYPE.value();
+      }
+    },
+
+    AI_PROVIDER {
+      @Override
+      public String asString() {
+        return AiObservationAttributes.AI_PROVIDER.value();
+      }
+    },
+
+    REQUEST_MODEL {
+      @Override
+      public String asString() {
+        return AiObservationAttributes.REQUEST_MODEL.value();
+      }
+    },
+
+    RESPONSE_MODEL {
+      @Override
+      public String asString() {
+        return AiObservationAttributes.RESPONSE_MODEL.value();
+      }
+    }
+  }
+
+  /** High-cardinality observation key names for rerank model operations. */
+  public enum HighCardinalityKeyNames implements KeyName {
+    DOCUMENT_COUNT {
+      @Override
+      public String asString() {
+        return "gen_ai.rerank.document_count";
+      }
+    },
+
+    TOP_N {
+      @Override
+      public String asString() {
+        return "gen_ai.rerank.top_n";
+      }
+    },
+
+    USAGE_INPUT_TOKENS {
+      @Override
+      public String asString() {
+        return AiObservationAttributes.USAGE_INPUT_TOKENS.value();
+      }
+    }
+  }
+}

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/rerank/WatsonxAiDocumentRerankerTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/rerank/WatsonxAiDocumentRerankerTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+
+/**
+ * JUnit 5 test class for WatsonxAiDocumentReranker functionality. Tests the DocumentPostProcessor
+ * integration with rerank model.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+class WatsonxAiDocumentRerankerTest {
+
+  @Mock private WatsonxAiRerankModel rerankModel;
+
+  private WatsonxAiDocumentReranker documentReranker;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    documentReranker = new WatsonxAiDocumentReranker(rerankModel);
+  }
+
+  @Nested
+  class ConstructorTests {
+
+    @Test
+    void constructorWithValidRerankModel() {
+      assertNotNull(documentReranker);
+    }
+
+    @Test
+    void constructorWithNullRerankModelThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new WatsonxAiDocumentReranker(null),
+          "WatsonxAiRerankModel must not be null");
+    }
+
+    @Test
+    void constructorWithOptionsIsValid() {
+      WatsonxAiRerankOptions options = WatsonxAiRerankOptions.builder().topN(5).build();
+      WatsonxAiDocumentReranker reranker = new WatsonxAiDocumentReranker(rerankModel, options);
+      assertNotNull(reranker);
+    }
+  }
+
+  @Nested
+  class ProcessMethodTests {
+
+    @Test
+    void processWithValidDocuments() {
+      Query query = new Query("What is machine learning?");
+      List<Document> documents =
+          List.of(
+              Document.builder().id("1").text("Machine learning is AI.").build(),
+              Document.builder().id("2").text("Cooking recipes.").build(),
+              Document.builder().id("3").text("Deep learning networks.").build());
+
+      WatsonxAiRerankResponse.RerankResult result1 =
+          new WatsonxAiRerankResponse.RerankResult(0, 0.95, null);
+      WatsonxAiRerankResponse.RerankResult result2 =
+          new WatsonxAiRerankResponse.RerankResult(2, 0.85, null);
+      WatsonxAiRerankResponse.RerankResult result3 =
+          new WatsonxAiRerankResponse.RerankResult(1, 0.25, null);
+
+      when(rerankModel.rerank(anyString(), anyList(), any()))
+          .thenReturn(List.of(result1, result2, result3));
+
+      List<Document> rerankedDocuments = documentReranker.process(query, documents);
+
+      assertNotNull(rerankedDocuments);
+      assertEquals(3, rerankedDocuments.size());
+
+      // First document should be the highest scoring (index 0)
+      assertEquals("1", rerankedDocuments.get(0).getId());
+      assertEquals(0.95, rerankedDocuments.get(0).getScore(), 0.001);
+      assertEquals(
+          0.95,
+          rerankedDocuments
+              .get(0)
+              .getMetadata()
+              .get(WatsonxAiDocumentReranker.RERANK_SCORE_METADATA_KEY));
+
+      // Second document should be index 2
+      assertEquals("3", rerankedDocuments.get(1).getId());
+      assertEquals(0.85, rerankedDocuments.get(1).getScore(), 0.001);
+
+      // Third document should be index 1
+      assertEquals("2", rerankedDocuments.get(2).getId());
+      assertEquals(0.25, rerankedDocuments.get(2).getScore(), 0.001);
+
+      verify(rerankModel, times(1)).rerank(anyString(), anyList(), any());
+    }
+
+    @Test
+    void processWithEmptyDocuments() {
+      Query query = new Query("What is AI?");
+      List<Document> documents = List.of();
+
+      List<Document> rerankedDocuments = documentReranker.process(query, documents);
+
+      assertNotNull(rerankedDocuments);
+      assertTrue(rerankedDocuments.isEmpty());
+      verify(rerankModel, never()).rerank(anyString(), anyList(), any());
+    }
+
+    @Test
+    void processWithNullDocuments() {
+      Query query = new Query("What is AI?");
+
+      List<Document> rerankedDocuments = documentReranker.process(query, null);
+
+      assertNotNull(rerankedDocuments);
+      assertTrue(rerankedDocuments.isEmpty());
+      verify(rerankModel, never()).rerank(anyString(), anyList(), any());
+    }
+
+    @Test
+    void processWithNullQueryThrowsException() {
+      List<Document> documents = List.of(Document.builder().id("1").text("Test").build());
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> documentReranker.process(null, documents),
+          "Query must not be null");
+    }
+
+    @Test
+    void processPreservesDocumentMetadata() {
+      Query query = new Query("Test query");
+      Document originalDoc =
+          Document.builder()
+              .id("1")
+              .text("Test document")
+              .metadata(Map.of("source", "test", "page", 1))
+              .build();
+
+      WatsonxAiRerankResponse.RerankResult result =
+          new WatsonxAiRerankResponse.RerankResult(0, 0.9, null);
+
+      when(rerankModel.rerank(anyString(), anyList(), any())).thenReturn(List.of(result));
+
+      List<Document> rerankedDocuments = documentReranker.process(query, List.of(originalDoc));
+
+      assertEquals(1, rerankedDocuments.size());
+      Document rerankedDoc = rerankedDocuments.get(0);
+
+      // Original metadata should be preserved
+      assertEquals("test", rerankedDoc.getMetadata().get("source"));
+      assertEquals(1, rerankedDoc.getMetadata().get("page"));
+      // Plus the new rerank score
+      assertEquals(
+          0.9, rerankedDoc.getMetadata().get(WatsonxAiDocumentReranker.RERANK_SCORE_METADATA_KEY));
+    }
+
+    @Test
+    void processHandlesRerankModelReturningEmptyResults() {
+      Query query = new Query("Test query");
+      List<Document> documents = List.of(Document.builder().id("1").text("Test").build());
+
+      when(rerankModel.rerank(anyString(), anyList(), any())).thenReturn(List.of());
+
+      List<Document> rerankedDocuments = documentReranker.process(query, documents);
+
+      // Should return original documents when rerank returns empty
+      assertEquals(1, rerankedDocuments.size());
+    }
+
+    @Test
+    void processHandlesRerankModelReturningNull() {
+      Query query = new Query("Test query");
+      List<Document> documents = List.of(Document.builder().id("1").text("Test").build());
+
+      when(rerankModel.rerank(anyString(), anyList(), any())).thenReturn(null);
+
+      List<Document> rerankedDocuments = documentReranker.process(query, documents);
+
+      // Should return original documents when rerank returns null
+      assertEquals(1, rerankedDocuments.size());
+    }
+  }
+
+  @Nested
+  class ApplyMethodTests {
+
+    @Test
+    void applyDelegatesToProcess() {
+      Query query = new Query("Test query");
+      List<Document> documents = List.of(Document.builder().id("1").text("Test").build());
+
+      WatsonxAiRerankResponse.RerankResult result =
+          new WatsonxAiRerankResponse.RerankResult(0, 0.9, null);
+
+      when(rerankModel.rerank(anyString(), anyList(), any())).thenReturn(List.of(result));
+
+      // apply() should delegate to process()
+      List<Document> rerankedDocuments = documentReranker.apply(query, documents);
+
+      assertNotNull(rerankedDocuments);
+      assertEquals(1, rerankedDocuments.size());
+      verify(rerankModel, times(1)).rerank(anyString(), anyList(), any());
+    }
+  }
+}

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankModelIT.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankModelIT.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+import io.micrometer.observation.ObservationRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Integration test class for WatsonxAiRerankModel using MockRestServiceServer. This test
+ * demonstrates integration with the watsonx.ai Rerank API.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+public class WatsonxAiRerankModelIT {
+
+  private RestClient.Builder restClientBuilder;
+
+  private MockRestServiceServer mockServer;
+
+  private WatsonxAiRerankApi watsonxAiRerankApi;
+
+  private WatsonxAiRerankModel rerankModel;
+
+  private static final String BASE_URL = "https://us-south.ml.cloud.ibm.com";
+  private static final String RERANK_ENDPOINT = "/ml/v1/text/rerank";
+  private static final String VERSION = "2024-05-31";
+  private static final String PROJECT_ID = "test-project-id";
+  private static final String SPACE_ID = "test-space-id";
+  private static final String API_KEY = "test-api-key";
+
+  @BeforeEach
+  void setUp() {
+    restClientBuilder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+
+    ResponseErrorHandler errorHandler =
+        response -> {
+          HttpStatus.Series series = HttpStatus.Series.resolve(response.getStatusCode().value());
+          return (series == HttpStatus.Series.CLIENT_ERROR
+              || series == HttpStatus.Series.SERVER_ERROR);
+        };
+
+    watsonxAiRerankApi =
+        new WatsonxAiRerankApi(
+            BASE_URL,
+            RERANK_ENDPOINT,
+            VERSION,
+            PROJECT_ID,
+            SPACE_ID,
+            API_KEY,
+            restClientBuilder,
+            errorHandler);
+
+    WatsonxAiRerankOptions defaultOptions =
+        WatsonxAiRerankOptions.builder()
+            .model("cross-encoder/ms-marco-minilm-l-12-v2")
+            .truncateInputTokens(512)
+            .build();
+
+    rerankModel =
+        new WatsonxAiRerankModel(
+            watsonxAiRerankApi,
+            defaultOptions,
+            ObservationRegistry.NOOP,
+            RetryUtils.DEFAULT_RETRY_TEMPLATE);
+  }
+
+  @Test
+  void rerankWithSingleDocumentTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+          "model_version": "1.0.0",
+          "results": [
+            {
+              "index": 0,
+              "score": 0.95
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 10
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    List<String> documents = List.of("Machine learning is a subset of AI.");
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("What is machine learning?", documents);
+
+    assertNotNull(results);
+    assertEquals(1, results.size());
+    assertEquals(0, results.get(0).index());
+    assertEquals(0.95, results.get(0).score(), 0.001);
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankWithMultipleDocumentsTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+          "model_version": "1.0.0",
+          "results": [
+            {
+              "index": 0,
+              "score": 0.95
+            },
+            {
+              "index": 2,
+              "score": 0.82
+            },
+            {
+              "index": 1,
+              "score": 0.15
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 25
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    List<String> documents =
+        List.of(
+            "Machine learning is a subset of artificial intelligence.",
+            "Cooking Italian pasta requires fresh ingredients.",
+            "Deep learning uses neural networks with many layers.");
+
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("What is machine learning?", documents);
+
+    assertNotNull(results);
+    assertEquals(3, results.size());
+
+    // First result should be the highest scoring
+    assertEquals(0, results.get(0).index());
+    assertEquals(0.95, results.get(0).score(), 0.001);
+
+    // Second result
+    assertEquals(2, results.get(1).index());
+    assertEquals(0.82, results.get(1).score(), 0.001);
+
+    // Third result (lowest score)
+    assertEquals(1, results.get(2).index());
+    assertEquals(0.15, results.get(2).score(), 0.001);
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankWithCustomOptionsTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "custom-rerank-model",
+          "model_version": "2.0.0",
+          "results": [
+            {
+              "index": 0,
+              "score": 0.88,
+              "input": {
+                "text": "Machine learning is AI"
+              }
+            },
+            {
+              "index": 1,
+              "score": 0.72,
+              "input": {
+                "text": "Deep learning uses neural networks"
+              }
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 15,
+          "query": "What is AI?"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    WatsonxAiRerankOptions customOptions =
+        WatsonxAiRerankOptions.builder()
+            .model("custom-rerank-model")
+            .topN(2)
+            .truncateInputTokens(1024)
+            .returnInputs(true)
+            .returnQuery(true)
+            .build();
+
+    List<String> documents =
+        List.of("Machine learning is AI", "Deep learning uses neural networks", "Cooking recipes");
+
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("What is AI?", documents, customOptions);
+
+    assertNotNull(results);
+    assertEquals(2, results.size());
+
+    assertEquals(0, results.get(0).index());
+    assertEquals(0.88, results.get(0).score(), 0.001);
+    assertNotNull(results.get(0).input());
+    assertEquals("Machine learning is AI", results.get(0).input().text());
+
+    assertEquals(1, results.get(1).index());
+    assertEquals(0.72, results.get(1).score(), 0.001);
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankWithTopNLimitTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+          "model_version": "1.0.0",
+          "results": [
+            {
+              "index": 0,
+              "score": 0.95
+            },
+            {
+              "index": 2,
+              "score": 0.85
+            },
+            {
+              "index": 3,
+              "score": 0.75
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 30
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    WatsonxAiRerankOptions options = WatsonxAiRerankOptions.builder().topN(3).build();
+
+    List<String> documents =
+        List.of("Doc 1 - ML", "Doc 2 - Cooking", "Doc 3 - DL", "Doc 4 - NLP", "Doc 5 - CV");
+
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("Machine learning topics", documents, options);
+
+    assertNotNull(results);
+    assertEquals(3, results.size());
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankWithEmptyResponseTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+          "model_version": "1.0.0",
+          "results": [],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 5
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    List<String> documents = List.of("Some document");
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("Unrelated query", documents);
+
+    assertNotNull(results);
+    assertTrue(results.isEmpty());
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankWithTruncateInputTokensTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+          "model_version": "1.0.0",
+          "results": [
+            {
+              "index": 0,
+              "score": 0.78
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 256
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    WatsonxAiRerankOptions options =
+        WatsonxAiRerankOptions.builder().truncateInputTokens(256).build();
+
+    String longDocument =
+        "This is a very long document that contains multiple sentences and paragraphs. "
+            + "It should be truncated by the model if it exceeds the specified token limit. "
+            + "The truncation ensures that the model can process the input without issues.";
+
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("What is this about?", List.of(longDocument), options);
+
+    assertNotNull(results);
+    assertEquals(1, results.size());
+    assertEquals(0.78, results.get(0).score(), 0.001);
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankWithInputTextInResponseTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+          "model_version": "1.0.0",
+          "results": [
+            {
+              "index": 0,
+              "score": 0.92,
+              "input": {
+                "text": "Original document text"
+              }
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 8
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    WatsonxAiRerankOptions options = WatsonxAiRerankOptions.builder().returnInputs(true).build();
+
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("Query text", List.of("Original document text"), options);
+
+    assertNotNull(results);
+    assertEquals(1, results.size());
+
+    WatsonxAiRerankResponse.RerankResult result = results.get(0);
+    assertEquals(0, result.index());
+    assertEquals(0.92, result.score(), 0.001);
+    assertNotNull(result.input());
+    assertEquals("Original document text", result.input().text());
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankWithDifferentModelsTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "ibm/rerank-v1",
+          "model_version": "1.0.0",
+          "results": [
+            {
+              "index": 1,
+              "score": 0.89
+            },
+            {
+              "index": 0,
+              "score": 0.67
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 20
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    WatsonxAiRerankOptions options =
+        WatsonxAiRerankOptions.builder().model("ibm/rerank-v1").build();
+
+    List<String> documents = List.of("Document A about technology", "Document B about science");
+
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("Science and research", documents, options);
+
+    assertNotNull(results);
+    assertEquals(2, results.size());
+
+    // Results should be sorted by score
+    assertEquals(1, results.get(0).index());
+    assertEquals(0.89, results.get(0).score(), 0.001);
+
+    assertEquals(0, results.get(1).index());
+    assertEquals(0.67, results.get(1).score(), 0.001);
+
+    mockServer.verify();
+  }
+
+  @Test
+  void rerankPreservesDefaultOptionsTest() {
+    String jsonResponse =
+        """
+        {
+          "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+          "model_version": "1.0.0",
+          "results": [
+            {
+              "index": 0,
+              "score": 0.75
+            }
+          ],
+          "created_at": "2024-01-15T10:30:00.000Z",
+          "input_token_count": 5
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(BASE_URL + RERANK_ENDPOINT + "?version=" + VERSION))
+        .andExpect(method(org.springframework.http.HttpMethod.POST))
+        .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+    // Call without runtime options - should use defaults
+    List<WatsonxAiRerankResponse.RerankResult> results =
+        rerankModel.rerank("Test query", List.of("Test document"));
+
+    assertNotNull(results);
+    assertEquals(1, results.size());
+
+    // Verify default options are still intact
+    WatsonxAiRerankOptions defaultOptions = rerankModel.getDefaultOptions();
+    assertEquals("cross-encoder/ms-marco-minilm-l-12-v2", defaultOptions.getModel());
+    assertEquals(512, defaultOptions.getTruncateInputTokens());
+
+    mockServer.verify();
+  }
+}

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankModelTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/rerank/WatsonxAiRerankModelTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.watsonx.rerank;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.micrometer.observation.ObservationRegistry;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * JUnit 5 test class for WatsonxAiRerankModel functionality. Tests rerank model operations using
+ * mocking for external dependencies.
+ *
+ * @author Federico Mariani
+ * @since 1.1.0-SNAPSHOT
+ */
+class WatsonxAiRerankModelTest {
+
+  @Mock private WatsonxAiRerankApi watsonxAiRerankApi;
+
+  @Mock private RetryTemplate retryTemplate;
+
+  private WatsonxAiRerankModel rerankModel;
+  private WatsonxAiRerankOptions defaultOptions;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    defaultOptions =
+        WatsonxAiRerankOptions.builder()
+            .model("cross-encoder/ms-marco-minilm-l-12-v2")
+            .truncateInputTokens(512)
+            .build();
+
+    rerankModel =
+        new WatsonxAiRerankModel(
+            watsonxAiRerankApi, defaultOptions, ObservationRegistry.NOOP, retryTemplate);
+
+    doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              org.springframework.retry.RetryCallback<Object, Exception> callback =
+                  (org.springframework.retry.RetryCallback<Object, Exception>)
+                      invocation.getArgument(0);
+              return callback.doWithRetry(null);
+            })
+        .when(retryTemplate)
+        .execute(any());
+  }
+
+  @Nested
+  class ConstructorTests {
+
+    @Test
+    void constructorWithValidParameters() {
+      assertNotNull(rerankModel);
+      assertEquals(defaultOptions, rerankModel.getDefaultOptions());
+    }
+
+    @Test
+    void constructorWithNullApiThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              new WatsonxAiRerankModel(
+                  null, defaultOptions, ObservationRegistry.NOOP, retryTemplate),
+          "WatsonxAiRerankApi must not be null");
+    }
+
+    @Test
+    void constructorWithNullOptionsThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              new WatsonxAiRerankModel(
+                  watsonxAiRerankApi, null, ObservationRegistry.NOOP, retryTemplate),
+          "WatsonxAiRerankOptions must not be null");
+    }
+
+    @Test
+    void constructorWithNullObservationRegistryThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new WatsonxAiRerankModel(watsonxAiRerankApi, defaultOptions, null, retryTemplate),
+          "ObservationRegistry must not be null");
+    }
+
+    @Test
+    void constructorWithNullRetryTemplateThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              new WatsonxAiRerankModel(
+                  watsonxAiRerankApi, defaultOptions, ObservationRegistry.NOOP, null),
+          "RetryTemplate must not be null");
+    }
+  }
+
+  @Nested
+  class RerankMethodTests {
+
+    @Test
+    void rerankWithValidRequest() {
+      String query = "What is machine learning?";
+      List<String> documents =
+          List.of(
+              "Machine learning is a subset of AI.",
+              "Cooking recipes are great.",
+              "Deep learning uses neural networks.");
+
+      WatsonxAiRerankResponse.RerankResult result1 =
+          new WatsonxAiRerankResponse.RerankResult(0, 0.95, null);
+      WatsonxAiRerankResponse.RerankResult result2 =
+          new WatsonxAiRerankResponse.RerankResult(2, 0.85, null);
+      WatsonxAiRerankResponse.RerankResult result3 =
+          new WatsonxAiRerankResponse.RerankResult(1, 0.25, null);
+
+      WatsonxAiRerankResponse mockResponse =
+          new WatsonxAiRerankResponse(
+              "cross-encoder/ms-marco-minilm-l-12-v2",
+              "1.0",
+              List.of(result1, result2, result3),
+              LocalDateTime.now(),
+              15,
+              query);
+
+      when(watsonxAiRerankApi.rerank(any(WatsonxAiRerankRequest.class)))
+          .thenReturn(ResponseEntity.ok(mockResponse));
+
+      List<WatsonxAiRerankResponse.RerankResult> results = rerankModel.rerank(query, documents);
+
+      assertNotNull(results);
+      assertEquals(3, results.size());
+      assertEquals(0.95, results.get(0).score(), 0.001);
+      assertEquals(0, results.get(0).index());
+      verify(watsonxAiRerankApi, times(1)).rerank(any(WatsonxAiRerankRequest.class));
+    }
+
+    @Test
+    void rerankWithNullQueryThrowsException() {
+      List<String> documents = List.of("Document 1", "Document 2");
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> rerankModel.rerank(null, documents),
+          "Query must not be null or empty");
+    }
+
+    @Test
+    void rerankWithEmptyQueryThrowsException() {
+      List<String> documents = List.of("Document 1", "Document 2");
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> rerankModel.rerank("", documents),
+          "Query must not be null or empty");
+    }
+
+    @Test
+    void rerankWithEmptyDocumentsThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> rerankModel.rerank("What is AI?", List.of()),
+          "Documents must not be empty");
+    }
+
+    @Test
+    void rerankWithNullDocumentsThrowsException() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> rerankModel.rerank("What is AI?", null),
+          "Documents must not be empty");
+    }
+
+    @Test
+    void rerankWithCustomOptions() {
+      String query = "Test query";
+      List<String> documents = List.of("Document 1");
+
+      WatsonxAiRerankOptions customOptions =
+          WatsonxAiRerankOptions.builder().model("custom-model").topN(5).build();
+
+      WatsonxAiRerankResponse.RerankResult result =
+          new WatsonxAiRerankResponse.RerankResult(0, 0.9, null);
+
+      WatsonxAiRerankResponse mockResponse =
+          new WatsonxAiRerankResponse(
+              "custom-model", "1.0", List.of(result), LocalDateTime.now(), 5, query);
+
+      when(watsonxAiRerankApi.rerank(any(WatsonxAiRerankRequest.class)))
+          .thenReturn(ResponseEntity.ok(mockResponse));
+
+      List<WatsonxAiRerankResponse.RerankResult> results =
+          rerankModel.rerank(query, documents, customOptions);
+
+      assertNotNull(results);
+      assertEquals(1, results.size());
+      verify(watsonxAiRerankApi, times(1)).rerank(any(WatsonxAiRerankRequest.class));
+    }
+  }
+
+  @Nested
+  class OptionsMergingTests {
+
+    @Test
+    void mergeOptionsWithRuntimeModel() {
+      WatsonxAiRerankOptions runtimeOptions =
+          WatsonxAiRerankOptions.builder().model("runtime-model").build();
+
+      String query = "Test query";
+      List<String> documents = List.of("Document 1");
+
+      WatsonxAiRerankResponse.RerankResult result =
+          new WatsonxAiRerankResponse.RerankResult(0, 0.9, null);
+      WatsonxAiRerankResponse mockResponse =
+          new WatsonxAiRerankResponse(
+              "runtime-model", "1.0", List.of(result), LocalDateTime.now(), 5, query);
+
+      when(watsonxAiRerankApi.rerank(any(WatsonxAiRerankRequest.class)))
+          .thenReturn(ResponseEntity.ok(mockResponse));
+
+      List<WatsonxAiRerankResponse.RerankResult> results =
+          rerankModel.rerank(query, documents, runtimeOptions);
+
+      assertNotNull(results);
+      verify(watsonxAiRerankApi, times(1)).rerank(any(WatsonxAiRerankRequest.class));
+    }
+
+    @Test
+    void mergeOptionsWithRuntimeTopN() {
+      WatsonxAiRerankOptions runtimeOptions = WatsonxAiRerankOptions.builder().topN(3).build();
+
+      String query = "Test query";
+      List<String> documents = List.of("Document 1", "Document 2", "Document 3", "Document 4");
+
+      WatsonxAiRerankResponse.RerankResult result1 =
+          new WatsonxAiRerankResponse.RerankResult(0, 0.9, null);
+      WatsonxAiRerankResponse.RerankResult result2 =
+          new WatsonxAiRerankResponse.RerankResult(1, 0.8, null);
+      WatsonxAiRerankResponse.RerankResult result3 =
+          new WatsonxAiRerankResponse.RerankResult(2, 0.7, null);
+
+      WatsonxAiRerankResponse mockResponse =
+          new WatsonxAiRerankResponse(
+              "cross-encoder/ms-marco-minilm-l-12-v2",
+              "1.0",
+              List.of(result1, result2, result3),
+              LocalDateTime.now(),
+              10,
+              query);
+
+      when(watsonxAiRerankApi.rerank(any(WatsonxAiRerankRequest.class)))
+          .thenReturn(ResponseEntity.ok(mockResponse));
+
+      List<WatsonxAiRerankResponse.RerankResult> results =
+          rerankModel.rerank(query, documents, runtimeOptions);
+
+      assertEquals(3, results.size());
+    }
+  }
+
+  @Nested
+  class ResponseHandlingTests {
+
+    @Test
+    void handleNullResponse() {
+      String query = "Test query";
+      List<String> documents = List.of("Document 1");
+
+      when(watsonxAiRerankApi.rerank(any(WatsonxAiRerankRequest.class)))
+          .thenReturn(ResponseEntity.ok(null));
+
+      List<WatsonxAiRerankResponse.RerankResult> results = rerankModel.rerank(query, documents);
+
+      assertNotNull(results);
+      assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void handleResponseWithNullResults() {
+      String query = "Test query";
+      List<String> documents = List.of("Document 1");
+
+      WatsonxAiRerankResponse mockResponse =
+          new WatsonxAiRerankResponse("test-model", "1.0", null, LocalDateTime.now(), 5, query);
+
+      when(watsonxAiRerankApi.rerank(any(WatsonxAiRerankRequest.class)))
+          .thenReturn(ResponseEntity.ok(mockResponse));
+
+      List<WatsonxAiRerankResponse.RerankResult> results = rerankModel.rerank(query, documents);
+
+      assertNotNull(results);
+      assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void handleResponseWithEmptyResults() {
+      String query = "Test query";
+      List<String> documents = List.of("Document 1");
+
+      WatsonxAiRerankResponse mockResponse =
+          new WatsonxAiRerankResponse(
+              "test-model", "1.0", List.of(), LocalDateTime.now(), 5, query);
+
+      when(watsonxAiRerankApi.rerank(any(WatsonxAiRerankRequest.class)))
+          .thenReturn(ResponseEntity.ok(mockResponse));
+
+      List<WatsonxAiRerankResponse.RerankResult> results = rerankModel.rerank(query, documents);
+
+      assertNotNull(results);
+      assertTrue(results.isEmpty());
+    }
+  }
+
+  @Nested
+  class DefaultOptionsTests {
+
+    @Test
+    void getDefaultOptionsReturnsCorrectOptions() {
+      WatsonxAiRerankOptions retrievedOptions = rerankModel.getDefaultOptions();
+
+      assertAll(
+          "Default options validation",
+          () -> assertEquals(defaultOptions, retrievedOptions),
+          () -> assertEquals("cross-encoder/ms-marco-minilm-l-12-v2", retrievedOptions.getModel()),
+          () -> assertEquals(512, retrievedOptions.getTruncateInputTokens()));
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/spring-ai-community/spring-ai-watsonx-ai/issues/59 Add rerank/scoring integration with Spring AI.

Currently, Spring AI does not support reranking natively. This PR introduces the following changes to provide reranking functionality:

* Added a `DocumentPostProcessor` that can be used to rerank documents during retrieval:
```
Autowired
WatsonxAiDocumentReranker documentReranker;

...

RetrievalAugmentationAdvisor.builder()
            .documentRetriever(VectorStoreDocumentRetriever.builder()
                .vectorStore(vectorStore)
                .build())
            .documentPostProcessors(documentReranker) // <-- documentReranker can be autowired
            .build();
```
* Implemented observability support: Since reranking is not yet implemented in Spring AI, I also had to implement the observability components. @rjtmahinay, the observability implementation follows the same patterns that Spring AI uses for Chat and Embedding. Please let me know if it's acceptable to include this in our repository, or if I should remove it for now. Once reranking is implemented in Spring AI core, we can refactor this code accordingly.  