### PR TITLE
Add logprobs metadata support for Watsonx chat

### DIFF
--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatModel.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatModel.java
@@ -378,6 +378,9 @@ public class WatsonxAiChatModel implements ChatModel {
     var generationMetadataBuilder =
         ChatGenerationMetadata.builder()
             .finishReason(choice.finishReason() != null ? choice.finishReason() : "");
+    if (Boolean.TRUE.equals(request.logprobs())) {
+      generationMetadataBuilder.metadata("logprobs", choice.logprobs());
+    }
 
     List<Media> media = new ArrayList<>();
     String textContent = choice.message().content();
@@ -416,6 +419,9 @@ public class WatsonxAiChatModel implements ChatModel {
     var generationMetadataBuilder =
         ChatGenerationMetadata.builder()
             .finishReason(choice.finishReason() != null ? choice.finishReason() : "");
+    if (Boolean.TRUE.equals(request.logprobs())) {
+      generationMetadataBuilder.metadata("logprobs", choice.logprobs());
+    }
 
     List<Media> media = new ArrayList<>();
     String textContent = choice.delta().content();

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatOptions.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatOptions.java
@@ -532,6 +532,9 @@ public class WatsonxAiChatOptions implements ToolCallingChatOptions {
   }
 
   public void setLogprobs(Boolean logprobs) {
+    if (Boolean.FALSE.equals(logprobs) && this.topLogprobs != null) {
+      throw new IllegalArgumentException("logprobs cannot be false when using topLogprobs.");
+    }
     this.logprobs = logprobs;
   }
 
@@ -540,8 +543,7 @@ public class WatsonxAiChatOptions implements ToolCallingChatOptions {
   }
 
   public void setTopLogprobs(Integer topLogprobs) {
-    if (topLogprobs != null) {
-      Assert.notNull(this.logprobs, "logprobs cannot be null when using topLogprobs.");
+    if (topLogprobs != null && this.logprobs != null) {
       Assert.isTrue(this.logprobs, "logprobs cannot be false when using topLogprobs.");
     }
     this.topLogprobs = topLogprobs;

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatResponse.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatResponse.java
@@ -47,7 +47,8 @@ public record WatsonxAiChatResponse(
   public record TextChatResultChoice(
       @JsonProperty("index") Integer index,
       @JsonProperty("message") TextChatResultMessage message,
-      @JsonProperty("finish_reason") String finishReason) {}
+      @JsonProperty("finish_reason") String finishReason,
+      @JsonProperty("logprobs") TextChatLogProbs logprobs) {}
 
   /** A message in a chat completion response. */
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -68,6 +69,27 @@ public record WatsonxAiChatResponse(
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public record TextChatFunctionCall(
       @JsonProperty("name") String name, @JsonProperty("arguments") String arguments) {}
+
+  /** Log probability details for the generated chat content. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record TextChatLogProbs(
+      @JsonProperty("content") List<TextChatLogProbsContent> content,
+      @JsonProperty("refusal") List<TextChatLogProbsContent> refusal) {}
+
+  /** Log probability details for a single generated token. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record TextChatLogProbsContent(
+      @JsonProperty("token") String token,
+      @JsonProperty("logprob") Double logprob,
+      @JsonProperty("bytes") List<Integer> bytes,
+      @JsonProperty("top_logprobs") List<TextChatTopLogProbs> topLogprobs) {}
+
+  /** Alternative token probability returned for a generated token position. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record TextChatTopLogProbs(
+      @JsonProperty("token") String token,
+      @JsonProperty("logprob") Double logprob,
+      @JsonProperty("bytes") List<Integer> bytes) {}
 
   /** Usage statistics for the completion request. */
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatStream.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/WatsonxAiChatStream.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import org.springaicommunity.watsonx.chat.WatsonxAiChatResponse.TextChatLogProbs;
 import org.springaicommunity.watsonx.chat.WatsonxAiChatResponse.TextChatUsage;
 import org.springaicommunity.watsonx.chat.util.ChatRole;
 import org.springaicommunity.watsonx.chat.util.ToolType;
@@ -47,7 +48,8 @@ public record WatsonxAiChatStream(
   public record TextChatResultChoiceStream(
       @JsonProperty("index") Integer index,
       @JsonProperty("delta") TextChatResultDelta delta,
-      @JsonProperty("finish_reason") String finishReason) {}
+      @JsonProperty("finish_reason") String finishReason,
+      @JsonProperty("logprobs") TextChatLogProbs logprobs) {}
 
   /** A message in a chat completion response. */
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/util/WatsonxAiChatChunkMerger.java
+++ b/watsonx-ai-core/src/main/java/org/springaicommunity/watsonx/chat/util/WatsonxAiChatChunkMerger.java
@@ -133,7 +133,11 @@ public class WatsonxAiChatChunkMerger {
 
     TextChatResultDelta delta = merge(previous.delta(), current.delta());
 
-    return new TextChatResultChoiceStream(index, delta, finishReason);
+    return new TextChatResultChoiceStream(
+        index,
+        delta,
+        finishReason,
+        current.logprobs() != null ? current.logprobs() : previous.logprobs());
   }
 
   private TextChatResultDelta merge(TextChatResultDelta previous, TextChatResultDelta current) {

--- a/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/chat/WatsonxAiChatModelTest.java
+++ b/watsonx-ai-core/src/test/java/org/springaicommunity/watsonx/chat/WatsonxAiChatModelTest.java
@@ -20,10 +20,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.observation.ObservationRegistry;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -123,7 +125,8 @@ public class WatsonxAiChatModelTest {
                 "Hello! How can I help you today?",
                 null,
                 null),
-            "stop");
+            "stop",
+            null);
 
     WatsonxAiChatResponse mockResponse =
         new WatsonxAiChatResponse(
@@ -151,6 +154,157 @@ public class WatsonxAiChatModelTest {
     assertEquals("Hello! How can I help you today?", generation.getOutput().getText());
 
     verify(watsonxAiChatApi, times(1)).chat(any(WatsonxAiChatRequest.class));
+  }
+
+  @Test
+  void chatModelCallAddsLogprobsMetadataWhenRequested() {
+    WatsonxAiChatResponse.TextChatLogProbs logprobs =
+        new WatsonxAiChatResponse.TextChatLogProbs(
+            List.of(
+                new WatsonxAiChatResponse.TextChatLogProbsContent(
+                    "Hello",
+                    -0.123,
+                    List.of(72, 101, 108, 108, 111),
+                    List.of(
+                        new WatsonxAiChatResponse.TextChatTopLogProbs(
+                            "Hello", -0.123, List.of(72, 101, 108, 108, 111)),
+                        new WatsonxAiChatResponse.TextChatTopLogProbs(
+                            "Hi", -1.456, List.of(72, 105))))),
+            null);
+
+    WatsonxAiChatResponse.TextChatResultChoice choice =
+        new WatsonxAiChatResponse.TextChatResultChoice(
+            0,
+            new WatsonxAiChatResponse.TextChatResultMessage(
+                org.springaicommunity.watsonx.chat.util.ChatRole.ASSISTANT, "Hello", null, null),
+            "stop",
+            logprobs);
+
+    WatsonxAiChatResponse mockResponse =
+        new WatsonxAiChatResponse(
+            "test-id",
+            "ibm/granite-3-3-8b-instruct",
+            1234567890,
+            List.of(choice),
+            "2024-01-01",
+            null,
+            new WatsonxAiChatResponse.TextChatUsage(10, 1, 11),
+            null);
+
+    when(watsonxAiChatApi.chat(any(WatsonxAiChatRequest.class)))
+        .thenReturn(ResponseEntity.ok(mockResponse));
+
+    Prompt prompt =
+        new Prompt(
+            new UserMessage("Hello"),
+            WatsonxAiChatOptions.builder().logProbs(true).topLogprobs(2).build());
+
+    ChatResponse response = chatModel.call(prompt);
+    var metadataLogprobs =
+        (WatsonxAiChatResponse.TextChatLogProbs) response.getResult().getMetadata().get("logprobs");
+
+    assertEquals(logprobs, metadataLogprobs);
+    assertEquals("Hello", metadataLogprobs.content().get(0).token());
+    assertEquals(-0.123, metadataLogprobs.content().get(0).logprob());
+    assertEquals(List.of(72, 101, 108, 108, 111), metadataLogprobs.content().get(0).bytes());
+    assertEquals("Hi", metadataLogprobs.content().get(0).topLogprobs().get(1).token());
+    assertEquals(-1.456, metadataLogprobs.content().get(0).topLogprobs().get(1).logprob());
+
+    ArgumentCaptor<WatsonxAiChatRequest> requestCaptor =
+        ArgumentCaptor.forClass(WatsonxAiChatRequest.class);
+    verify(watsonxAiChatApi).chat(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().logprobs());
+    assertEquals(2, requestCaptor.getValue().topLogprobs());
+  }
+
+  @Test
+  void chatModelCallDoesNotAddLogprobsMetadataWhenNotRequested() {
+    WatsonxAiChatResponse.TextChatLogProbs logprobs =
+        new WatsonxAiChatResponse.TextChatLogProbs(
+            List.of(
+                new WatsonxAiChatResponse.TextChatLogProbsContent(
+                    "Hello", -0.123, List.of(72, 101, 108, 108, 111), List.of())),
+            null);
+
+    WatsonxAiChatResponse.TextChatResultChoice choice =
+        new WatsonxAiChatResponse.TextChatResultChoice(
+            0,
+            new WatsonxAiChatResponse.TextChatResultMessage(
+                org.springaicommunity.watsonx.chat.util.ChatRole.ASSISTANT, "Hello", null, null),
+            "stop",
+            logprobs);
+
+    WatsonxAiChatResponse mockResponse =
+        new WatsonxAiChatResponse(
+            "test-id",
+            "ibm/granite-3-3-8b-instruct",
+            1234567890,
+            List.of(choice),
+            "2024-01-01",
+            null,
+            new WatsonxAiChatResponse.TextChatUsage(10, 1, 11),
+            null);
+
+    when(watsonxAiChatApi.chat(any(WatsonxAiChatRequest.class)))
+        .thenReturn(ResponseEntity.ok(mockResponse));
+
+    ChatResponse response = chatModel.call(new Prompt(new UserMessage("Hello")));
+
+    assertFalse(response.getResult().getMetadata().containsKey("logprobs"));
+  }
+
+  @Test
+  void deserializeChatResponseWithLogprobs() throws Exception {
+    String json =
+        """
+        {
+          "id": "chat-id",
+          "model_id": "ibm/granite-3-3-8b-instruct",
+          "created": 1234567890,
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hello"
+              },
+              "finish_reason": "stop",
+              "logprobs": {
+                "content": [
+                  {
+                    "token": "Hello",
+                    "logprob": -0.123,
+                    "bytes": [72, 101, 108, 108, 111],
+                    "top_logprobs": [
+                      {
+                        "token": "Hello",
+                        "logprob": -0.123,
+                        "bytes": [72, 101, 108, 108, 111]
+                      }
+                    ]
+                  }
+                ],
+                "refusal": []
+              }
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 1,
+            "total_tokens": 11
+          }
+        }
+        """;
+
+    WatsonxAiChatResponse response =
+        new ObjectMapper().readValue(json, WatsonxAiChatResponse.class);
+
+    WatsonxAiChatResponse.TextChatLogProbs logprobs = response.choices().get(0).logprobs();
+    assertNotNull(logprobs);
+    assertEquals("Hello", logprobs.content().get(0).token());
+    assertEquals(-0.123, logprobs.content().get(0).logprob());
+    assertEquals(List.of(72, 101, 108, 108, 111), logprobs.content().get(0).bytes());
+    assertEquals("Hello", logprobs.content().get(0).topLogprobs().get(0).token());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds response-side logprobs support for Watsonx chat completions.

This change:
- Maps `choices[].logprobs` in `WatsonxAiChatResponse`
- Maps streaming `choices[].logprobs` in `WatsonxAiChatStream`
- Exposes logprobs through Spring AI generation metadata using the `logprobs` key
- Preserves logprob token, logprob, bytes, and top_logprobs values
- Keeps logprobs metadata absent when the request did not enable logprobs
- Adjusts topLogprobs validation to work correctly during Spring AI options merging

## Tests

```powershell
.\mvnw.cmd -pl watsonx-ai-core -Dtest=WatsonxAiChatModelTest test
.\mvnw.cmd clean test